### PR TITLE
[Chore] 도커파일 & 도커 컴포즈 파일 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17
+COPY build/libs/peakly-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
-COPY build/libs/peakly-0.0.1-SNAPSHOT.jar app.jar
+FROM eclipse-temurin:21-jre-alpine
+COPY build/libs/*.jar app.jar
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,16 +5,15 @@ services:
     restart: unless-stopped
     environment:
       MYSQL_DATABASE: ${DB_NAME}
-      MYSQL_USER: ${DB_USERNAME}
-      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PW}
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       TZ: Asia/Seoul
     ports:
-      - "${DB_PORT}"
+      - "${DB_PORT}:3306"
     command: ["--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]
     volumes:
       - mysql_data:/var/lib/mysql
 
 volumes:
   mysql_data:
-  redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  mysql:
+    image: mysql:8.4
+    container_name: wearTrack-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      TZ: Asia/Seoul
+    ports:
+      - "${DB_PORT}"
+    command: ["--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+volumes:
+  mysql_data:
+  redis_data:

--- a/src/main/java/com/weartrack/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/weartrack/backend/global/config/SwaggerConfig.java
@@ -26,7 +26,7 @@ public class SwaggerConfig {
                         .version("1.0.0"))
 
                 .servers(List.of(
-                        new Server().url("https://weartrack.co.kr").description("Production"),
+                        new Server().url("https://wear-track.com").description("Production"),
                         new Server().url("http://localhost:8080").description("Local")))
 
                 .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))

--- a/src/main/java/com/weartrack/backend/global/controller/HealthController.java
+++ b/src/main/java/com/weartrack/backend/global/controller/HealthController.java
@@ -1,0 +1,17 @@
+package com.weartrack.backend.global.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/actuator/health")
+public class HealthController {
+    @GetMapping
+    public ResponseEntity<String> healthCheck(){
+        return  ResponseEntity.ok("Health OK");
+    }
+}


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->

- 배포를 위한 도커파일 설정
- 로컬환경 한번에 맞추고, 관리하기 위한 도커 컴포즈 파일 생성
- swagger에 도메인 수정

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 상태 확인용 Health 엔드포인트(/actuator/health) 추가 — 간단한 헬스 체크 응답 제공

* **Chores**
  * 런타임용 Docker 이미지 및 컨테이너 실행 설정 추가 (앱 포트 8080)
  * docker-compose에 MySQL 서비스 추가 및 데이터 영구화 볼륨 구성
  * UTF8MB4 문자 인코딩과 Asia/Seoul 타임존 적용, 컨테이너 자동 재시작 정책 설정

* **Documentation**
  * 공개 API 서버 URL(Production) 업데이트: wear-track 도메인 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->