### PR TITLE
FEAT: 옷장 등록 API 구현

### DIFF
--- a/src/main/java/com/weartrack/backend/domain/closet/controller/ClosetController.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/controller/ClosetController.java
@@ -1,0 +1,42 @@
+package com.weartrack.backend.domain.closet.controller;
+
+import com.weartrack.backend.domain.closet.dto.ClosetCreateReqDto;
+import com.weartrack.backend.domain.closet.dto.ClosetCreateResDto;
+import com.weartrack.backend.domain.closet.service.ClosetService;
+import com.weartrack.backend.global.response.ApiResponse;
+import com.weartrack.backend.global.security.JwtPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Closet", description = "옷장 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/closets")
+public class ClosetController {
+
+    private final ClosetService closetService;
+
+    @Operation(
+            summary = "옷장 등록",
+            description = "templateId + imageUrl + 사용자가 입력한 칸 이름을 저장"
+    )
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public ApiResponse<ClosetCreateResDto> createCloset(
+            @AuthenticationPrincipal JwtPrincipal principal,
+            @Valid @RequestBody ClosetCreateReqDto request
+    ) {
+
+        ClosetCreateResDto response = closetService.createCloset(
+                principal.memberId(),
+                request
+        );
+
+        return ApiResponse.success(response);
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/controller/ClosetPhotoController.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/controller/ClosetPhotoController.java
@@ -1,0 +1,45 @@
+package com.weartrack.backend.domain.closet.controller;
+
+import com.weartrack.backend.domain.closet.dto.ClosetPhotoCreateResDto;
+import com.weartrack.backend.domain.closet.service.ClosetPhotoService;
+import com.weartrack.backend.global.response.ApiResponse;
+import com.weartrack.backend.global.security.JwtPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "Closet", description = "옷장 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/closets")
+public class ClosetPhotoController {
+
+    private final ClosetPhotoService closetPhotoService;
+
+    @Operation(
+            summary = "옷장 사진 등록",
+            description = "옷장 사진 + templateId를 받아 이미지 저장 후 템플릿 기준 기본 칸 목록 반환"
+    )
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping(value = "/photo", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<ClosetPhotoCreateResDto> uploadClosetPhoto(
+            @AuthenticationPrincipal JwtPrincipal principal,
+            @RequestParam("templateId") @NotNull Integer templateId,
+            @RequestPart("image") MultipartFile image
+    ) {
+
+        ClosetPhotoCreateResDto response = closetPhotoService.uploadClosetPhoto(
+                principal.memberId(),
+                templateId,
+                image
+        );
+
+        return ApiResponse.success(response);
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/dto/ClosetCreateReqDto.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/dto/ClosetCreateReqDto.java
@@ -1,0 +1,20 @@
+package com.weartrack.backend.domain.closet.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record ClosetCreateReqDto(
+        @NotNull(message = "templateId는 필수입니다.")
+        Integer templateId,
+
+        @NotBlank(message = "imageUrl은 필수입니다.")
+        String imageUrl,
+
+        @NotEmpty(message = "칸 정보는 필수입니다.")
+        List<@Valid ClosetSectionCreateReqDto> sections
+) {
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/dto/ClosetCreateReqDto.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/dto/ClosetCreateReqDto.java
@@ -15,6 +15,6 @@ public record ClosetCreateReqDto(
         String imageUrl,
 
         @NotEmpty(message = "칸 정보는 필수입니다.")
-        List<@Valid ClosetSectionCreateReqDto> sections
+        List<@NotNull @Valid ClosetSectionCreateReqDto> sections
 ) {
 }

--- a/src/main/java/com/weartrack/backend/domain/closet/dto/ClosetCreateResDto.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/dto/ClosetCreateResDto.java
@@ -1,0 +1,11 @@
+package com.weartrack.backend.domain.closet.dto;
+
+import java.util.List;
+
+public record ClosetCreateResDto(
+        Long closetId,
+        Integer templateId,
+        String imageUrl,
+        List<ClosetSectionResDto> sections
+) {
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/dto/ClosetPhotoCreateResDto.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/dto/ClosetPhotoCreateResDto.java
@@ -1,0 +1,12 @@
+package com.weartrack.backend.domain.closet.dto;
+
+import java.util.List;
+
+public record ClosetPhotoCreateResDto(
+        String analysisStatus,
+        Integer templateId,
+        String imageUrl,
+        Integer predictedSectionCount,
+        List<PredictedSectionDto> predictedSections
+) {
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/dto/ClosetSectionCreateReqDto.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/dto/ClosetSectionCreateReqDto.java
@@ -1,0 +1,13 @@
+package com.weartrack.backend.domain.closet.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ClosetSectionCreateReqDto(
+        @NotNull(message = "sectionOrder는 필수입니다.")
+        Integer sectionOrder,
+
+        @NotBlank(message = "칸 이름을 모두 입력해주세요.")
+        String sectionName
+) {
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/dto/ClosetSectionResDto.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/dto/ClosetSectionResDto.java
@@ -1,0 +1,8 @@
+package com.weartrack.backend.domain.closet.dto;
+
+public record ClosetSectionResDto(
+        Long sectionId,
+        Integer sectionOrder,
+        String sectionName
+) {
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/dto/PredictedSectionDto.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/dto/PredictedSectionDto.java
@@ -1,0 +1,7 @@
+package com.weartrack.backend.domain.closet.dto;
+
+public record PredictedSectionDto(
+        Integer sectionOrder,
+        String sectionName
+) {
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/entity/Closet.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/entity/Closet.java
@@ -1,0 +1,39 @@
+package com.weartrack.backend.domain.closet.entity;
+
+import com.weartrack.backend.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "closet")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Closet extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "closet_id")
+    private Long closetId;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "template_id", nullable = false)
+    private Integer templateId;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "closet", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ClosetSection> sections = new ArrayList<>();
+
+    public void addSection(ClosetSection section) {
+        sections.add(section);
+        section.setCloset(this);
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/entity/ClosetSection.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/entity/ClosetSection.java
@@ -1,0 +1,32 @@
+package com.weartrack.backend.domain.closet.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "closet_section")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ClosetSection {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "section_id")
+    private Long sectionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "closet_id", nullable = false)
+    private Closet closet;
+
+    @Column(name = "section_order", nullable = false)
+    private Integer sectionOrder;
+
+    @Column(name = "section_name", nullable = false, length = 30)
+    private String sectionName;
+
+    public void setCloset(Closet closet) {
+        this.closet = closet;
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/entity/ClosetTemplate.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/entity/ClosetTemplate.java
@@ -1,0 +1,39 @@
+package com.weartrack.backend.domain.closet.entity;
+
+import com.weartrack.backend.domain.closet.exception.ClosetErrorCode;
+import com.weartrack.backend.global.exception.GeneralException;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+public enum ClosetTemplate {
+
+    TEMPLATE_1(1, 7),
+    TEMPLATE_2(2, 4),
+    TEMPLATE_3(3, 4),
+    TEMPLATE_4(4, 8),
+    TEMPLATE_5(5, 10);
+
+    private final Integer templateId;
+    private final Integer sectionCount;
+
+    ClosetTemplate(Integer templateId, Integer sectionCount) {
+        this.templateId = templateId;
+        this.sectionCount = sectionCount;
+    }
+
+    public static ClosetTemplate from(Integer templateId) {
+        return Arrays.stream(values())
+                .filter(template -> template.templateId.equals(templateId))
+                .findFirst()
+                .orElseThrow(() -> new GeneralException(ClosetErrorCode.INVALID_TEMPLATE_ID));
+    }
+
+    public List<Integer> getSectionOrders() {
+        return java.util.stream.IntStream.rangeClosed(1, sectionCount)
+                .boxed()
+                .toList();
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/exception/ClosetErrorCode.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/exception/ClosetErrorCode.java
@@ -1,0 +1,20 @@
+package com.weartrack.backend.domain.closet.exception;
+
+import com.weartrack.backend.global.exception.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ClosetErrorCode implements BaseErrorCode {
+
+    INVALID_TEMPLATE_ID("CLOSET_4001", "존재하지 않는 옷장 템플릿입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_SECTION_COUNT("CLOSET_4002", "템플릿의 칸 개수와 요청 칸 개수가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    EMPTY_SECTION_NAME("WARDROBE_4003", "칸 이름을 모두 입력해주세요.", HttpStatus.FORBIDDEN),
+    INVALID_IMAGE("CLOSET_4004", "옷장 이미지는 필수입니다.", HttpStatus.BAD_REQUEST);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/exception/ClosetErrorCode.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/exception/ClosetErrorCode.java
@@ -11,8 +11,10 @@ public enum ClosetErrorCode implements BaseErrorCode {
 
     INVALID_TEMPLATE_ID("CLOSET_4001", "존재하지 않는 옷장 템플릿입니다.", HttpStatus.BAD_REQUEST),
     INVALID_SECTION_COUNT("CLOSET_4002", "템플릿의 칸 개수와 요청 칸 개수가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
-    EMPTY_SECTION_NAME("WARDROBE_4003", "칸 이름을 모두 입력해주세요.", HttpStatus.FORBIDDEN),
-    INVALID_IMAGE("CLOSET_4004", "옷장 이미지는 필수입니다.", HttpStatus.BAD_REQUEST);
+    EMPTY_SECTION_NAME("CLOSET_4003", "칸 이름을 모두 입력해주세요.", HttpStatus.BAD_REQUEST),
+    INVALID_IMAGE("CLOSET_4004", "옷장 이미지는 필수입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_SECTION_ORDER("CLOSET_4005", "템플릿의 칸 순서가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    CLOSET_IMAGE_SAVE_FAILED("CLOSET_5001", "옷장 이미지 저장 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/weartrack/backend/domain/closet/repository/ClosetRepository.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/repository/ClosetRepository.java
@@ -1,0 +1,7 @@
+package com.weartrack.backend.domain.closet.repository;
+
+import com.weartrack.backend.domain.closet.entity.Closet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClosetRepository extends JpaRepository<Closet, Long> {
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/repository/ClosetSectionRepository.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/repository/ClosetSectionRepository.java
@@ -1,0 +1,7 @@
+package com.weartrack.backend.domain.closet.repository;
+
+import com.weartrack.backend.domain.closet.entity.ClosetSection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClosetSectionRepository extends JpaRepository<ClosetSection, Long> {
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/service/ClosetPhotoService.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/service/ClosetPhotoService.java
@@ -1,0 +1,37 @@
+package com.weartrack.backend.domain.closet.service;
+
+import com.weartrack.backend.domain.closet.dto.ClosetPhotoCreateResDto;
+import com.weartrack.backend.domain.closet.dto.PredictedSectionDto;
+import com.weartrack.backend.domain.closet.entity.ClosetTemplate;
+import com.weartrack.backend.domain.clothes.service.FileStorageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ClosetPhotoService {
+
+    private final FileStorageService fileStorageService;
+
+    public ClosetPhotoCreateResDto uploadClosetPhoto(Long memberId, Integer templateId, MultipartFile image) {
+        ClosetTemplate template = ClosetTemplate.from(templateId);
+
+        FileStorageService.SavedFile savedFile = fileStorageService.saveCloset(image);
+
+        List<PredictedSectionDto> predictedSections = template.getSectionOrders()
+                .stream()
+                .map(order -> new PredictedSectionDto(order, "칸" + order))
+                .toList();
+
+        return new ClosetPhotoCreateResDto(
+                "SUCCESS",
+                template.getTemplateId(),
+                savedFile.getImageUrl(),
+                template.getSectionCount(),
+                predictedSections
+        );
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/closet/service/ClosetPhotoService.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/service/ClosetPhotoService.java
@@ -17,6 +17,7 @@ public class ClosetPhotoService {
     private final FileStorageService fileStorageService;
 
     public ClosetPhotoCreateResDto uploadClosetPhoto(Long memberId, Integer templateId, MultipartFile image) {
+        // TODO: S3 이미지 저장 및 옷장 사진 이력 저장 시 memberId 사용 예정
         ClosetTemplate template = ClosetTemplate.from(templateId);
 
         FileStorageService.SavedFile savedFile = fileStorageService.saveCloset(image);

--- a/src/main/java/com/weartrack/backend/domain/closet/service/ClosetService.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/service/ClosetService.java
@@ -75,5 +75,16 @@ public class ClosetService {
         if (hasEmptyName) {
             throw new GeneralException(ClosetErrorCode.EMPTY_SECTION_NAME);
         }
+
+        List<Integer> sectionOrders = sections.stream()
+                .map(ClosetSectionCreateReqDto::sectionOrder)
+                .sorted()
+                .toList();
+
+        List<Integer> validOrders = template.getSectionOrders();
+
+        if (!sectionOrders.equals(validOrders)) {
+            throw new GeneralException(ClosetErrorCode.INVALID_SECTION_ORDER);
+        }
     }
 }

--- a/src/main/java/com/weartrack/backend/domain/closet/service/ClosetService.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/service/ClosetService.java
@@ -1,0 +1,79 @@
+package com.weartrack.backend.domain.closet.service;
+
+import com.weartrack.backend.domain.closet.dto.*;
+import com.weartrack.backend.domain.closet.entity.Closet;
+import com.weartrack.backend.domain.closet.entity.ClosetSection;
+import com.weartrack.backend.domain.closet.entity.ClosetTemplate;
+import com.weartrack.backend.domain.closet.exception.ClosetErrorCode;
+import com.weartrack.backend.domain.closet.repository.ClosetRepository;
+import com.weartrack.backend.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ClosetService {
+
+    private final ClosetRepository closetRepository;
+
+    public ClosetCreateResDto createCloset(Long memberId, ClosetCreateReqDto request) {
+        ClosetTemplate template = ClosetTemplate.from(request.templateId());
+
+        validateSections(template, request.sections());
+
+        Closet closet = Closet.builder()
+                .memberId(memberId)
+                .templateId(request.templateId())
+                .imageUrl(request.imageUrl())
+                .build();
+
+        request.sections()
+                .stream()
+                .sorted(Comparator.comparing(ClosetSectionCreateReqDto::sectionOrder))
+                .forEach(sectionRequest -> {
+                    ClosetSection section = ClosetSection.builder()
+                            .sectionOrder(sectionRequest.sectionOrder())
+                            .sectionName(sectionRequest.sectionName())
+                            .build();
+
+                    closet.addSection(section);
+                });
+
+        Closet savedCloset = closetRepository.save(closet);
+
+        List<ClosetSectionResDto> sectionResponses = savedCloset.getSections()
+                .stream()
+                .sorted(Comparator.comparing(ClosetSection::getSectionOrder))
+                .map(section -> new ClosetSectionResDto(
+                        section.getSectionId(),
+                        section.getSectionOrder(),
+                        section.getSectionName()
+                ))
+                .toList();
+
+        return new ClosetCreateResDto(
+                savedCloset.getClosetId(),
+                savedCloset.getTemplateId(),
+                savedCloset.getImageUrl(),
+                sectionResponses
+        );
+    }
+
+    private void validateSections(ClosetTemplate template, List<ClosetSectionCreateReqDto> sections) {
+        if (sections.size() != template.getSectionCount()) {
+            throw new GeneralException(ClosetErrorCode.INVALID_SECTION_COUNT);
+        }
+
+        boolean hasEmptyName = sections.stream()
+                .anyMatch(section -> section.sectionName() == null || section.sectionName().isBlank());
+
+        if (hasEmptyName) {
+            throw new GeneralException(ClosetErrorCode.EMPTY_SECTION_NAME);
+        }
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/FileStorageService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/FileStorageService.java
@@ -1,5 +1,7 @@
 package com.weartrack.backend.domain.clothes.service;
 
+import com.weartrack.backend.domain.closet.exception.ClosetErrorCode;
+import com.weartrack.backend.global.exception.GeneralException;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -94,7 +96,7 @@ public class FileStorageService {
         validateImage(image);
 
         try {
-            Path uploadPath = Paths.get("uploads/closets");
+            Path uploadPath = Paths.get(uploadDir, "closets");
 
             if (!Files.exists(uploadPath)) {
                 Files.createDirectories(uploadPath);
@@ -112,12 +114,12 @@ public class FileStorageService {
                     StandardCopyOption.REPLACE_EXISTING
             );
 
-            String imageUrl = "/uploads/closets/" + savedFilename;
+            String imageUrl = "/" + uploadDir + "/closets/" + savedFilename;
 
             return new SavedFile(imageUrl, savedPath.toFile());
 
         } catch (IOException e) {
-            throw new IllegalArgumentException("옷장 이미지 저장 중 오류가 발생했습니다.");
+            throw new GeneralException(ClosetErrorCode.CLOSET_IMAGE_SAVE_FAILED);
         }
     }
 }

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/FileStorageService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/FileStorageService.java
@@ -89,4 +89,35 @@ public class FileStorageService {
             this.file = file;
         }
     }
+
+    public SavedFile saveCloset(MultipartFile image) {
+        validateImage(image);
+
+        try {
+            Path uploadPath = Paths.get("uploads/closets");
+
+            if (!Files.exists(uploadPath)) {
+                Files.createDirectories(uploadPath);
+            }
+
+            String originalFilename = image.getOriginalFilename();
+            String extension = getExtension(originalFilename);
+            String savedFilename = UUID.randomUUID() + extension;
+
+            Path savedPath = uploadPath.resolve(savedFilename);
+
+            Files.copy(
+                    image.getInputStream(),
+                    savedPath,
+                    StandardCopyOption.REPLACE_EXISTING
+            );
+
+            String imageUrl = "/uploads/closets/" + savedFilename;
+
+            return new SavedFile(imageUrl, savedPath.toFile());
+
+        } catch (IOException e) {
+            throw new IllegalArgumentException("옷장 이미지 저장 중 오류가 발생했습니다.");
+        }
+    }
 }


### PR DESCRIPTION
### 👀 관련 이슈

(7)

### ✨ 작업한 내용

옷장 등록 기능 전체 구현 완료

1. 옷장 사진 등록 API
- POST /api/closets/photo
- 옷장 이미지 업로드 기능 구현
- templateId 기반으로 고정 템플릿 매칭
- 템플릿에 따른 기본 칸 목록 반환
- AI 없이 MVP 구조로 단순화

2. 옷장 등록 API
- POST /api/closets
- 사용자가 입력한 칸 이름 기반으로 옷장 저장
- Closet, ClosetSection 엔티티 연관관계 저장
- sectionOrder 기준 정렬 및 검증 로직 구현


### 🍰 참고사항

주요 구현 사항
- ClosetTemplate enum 기반 템플릿 관리
- sectionCount 기반 칸 개수 검증 로직 추가
- 빈 칸 이름 입력 방지 로직 추가
- FileStorageService를 활용한 이미지 업로드 처리
- ApiResponse 공통 응답 형식 유지

### 📷 스크린샷 또는 GIF

<img width="862" height="734" alt="스크린샷 2026-04-29 161052" src="https://github.com/user-attachments/assets/d6f9e51d-647c-4d2e-b042-24d3c9937945" />
<img width="865" height="732" alt="스크린샷 2026-04-29 161104" src="https://github.com/user-attachments/assets/a98768d6-a6e6-4768-ac2b-c18adaece273" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

## New Features
* 옷장 생성 기능 추가 - 템플릿을 선택하고 이미지를 업로드하여 맞춤형 옷장 구성
* 옷장 사진 업로드 기능 추가 - 이미지 분석을 통해 자동으로 옷장 섹션 예측 및 제안

<!-- end of auto-generated comment: release notes by coderabbit.ai -->