### PR TITLE
FEAT: 메인 홈 조회 API 구현

### DIFF
--- a/src/main/java/com/weartrack/backend/domain/clothes/repository/ClothesRepository.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/repository/ClothesRepository.java
@@ -9,21 +9,21 @@ import org.springframework.data.repository.query.Param;
 public interface ClothesRepository extends JpaRepository<Clothes, Long> {
 
     @Query("""
-            SELECT COUNT(c)
-            FROM Clothes c
-            JOIN ClothesPhoto cp ON c.clothesPhotoId = cp.id
-            WHERE cp.memberId = :memberId
-            """)
-    int countByMemberId(@Param("memberId") Long memberId);
+        SELECT COUNT(c)
+        FROM Clothes c
+        JOIN ClothesPhoto cp ON c.clothesPhotoId = cp.id
+        WHERE cp.memberId = :memberId
+        """)
+    long countByMemberId(@Param("memberId") Long memberId);
 
     @Query("""
-            SELECT COALESCE(SUM(c.price), 0)
-            FROM Clothes c
-            JOIN ClothesPhoto cp ON c.clothesPhotoId = cp.id
-            WHERE cp.memberId = :memberId
-              AND c.createdAt >= :startDate
-            """)
-    int sumWeeklyExpenseAmount(
+        SELECT COALESCE(SUM(c.price), 0L)
+        FROM Clothes c
+        JOIN ClothesPhoto cp ON c.clothesPhotoId = cp.id
+        WHERE cp.memberId = :memberId
+          AND c.createdAt >= :startDate
+        """)
+    long sumWeeklyExpenseAmount(
             @Param("memberId") Long memberId,
             @Param("startDate") LocalDateTime startDate
     );

--- a/src/main/java/com/weartrack/backend/domain/clothes/repository/ClothesRepository.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/repository/ClothesRepository.java
@@ -1,7 +1,30 @@
 package com.weartrack.backend.domain.clothes.repository;
 
 import com.weartrack.backend.domain.clothes.entity.Clothes;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ClothesRepository extends JpaRepository<Clothes, Long> {
+
+    @Query("""
+            SELECT COUNT(c)
+            FROM Clothes c
+            JOIN ClothesPhoto cp ON c.clothesPhotoId = cp.id
+            WHERE cp.memberId = :memberId
+            """)
+    int countByMemberId(@Param("memberId") Long memberId);
+
+    @Query("""
+            SELECT COALESCE(SUM(c.price), 0)
+            FROM Clothes c
+            JOIN ClothesPhoto cp ON c.clothesPhotoId = cp.id
+            WHERE cp.memberId = :memberId
+              AND c.createdAt >= :startDate
+            """)
+    int sumWeeklyExpenseAmount(
+            @Param("memberId") Long memberId,
+            @Param("startDate") LocalDateTime startDate
+    );
 }

--- a/src/main/java/com/weartrack/backend/domain/home/controller/HomeController.java
+++ b/src/main/java/com/weartrack/backend/domain/home/controller/HomeController.java
@@ -1,0 +1,33 @@
+package com.weartrack.backend.domain.home.controller;
+
+import com.weartrack.backend.domain.home.dto.HomeSummaryResDto;
+import com.weartrack.backend.domain.home.service.HomeService;
+import com.weartrack.backend.global.response.ApiResponse;
+import com.weartrack.backend.global.security.JwtPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Home", description = "메인 홈 관련 API")
+@RestController
+@RequiredArgsConstructor
+public class HomeController {
+
+    private final HomeService homeService;
+
+    @Operation(
+            summary = "메인 홈 조회",
+            description = "메인 홈 화면에 필요한 전체 옷 개수, 최근 1주일 소비 금액, 옷장 활용률을 조회합니다."
+    )
+    @GetMapping("/api/home")
+    public ApiResponse<HomeSummaryResDto> getHomeSummary(
+            @AuthenticationPrincipal JwtPrincipal principal
+    ) {
+        HomeSummaryResDto response = homeService.getHomeSummary(principal.memberId());
+
+        return ApiResponse.success(response);
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/home/dto/HomeSummaryResDto.java
+++ b/src/main/java/com/weartrack/backend/domain/home/dto/HomeSummaryResDto.java
@@ -1,0 +1,8 @@
+package com.weartrack.backend.domain.home.dto;
+
+public record HomeSummaryResDto(
+        int totalClothesCount,
+        int weeklyExpenseAmount,
+        int weeklyClosetUsageRate
+) {
+}

--- a/src/main/java/com/weartrack/backend/domain/home/dto/HomeSummaryResDto.java
+++ b/src/main/java/com/weartrack/backend/domain/home/dto/HomeSummaryResDto.java
@@ -1,8 +1,8 @@
 package com.weartrack.backend.domain.home.dto;
 
 public record HomeSummaryResDto(
-        int totalClothesCount,
-        int weeklyExpenseAmount,
+        long totalClothesCount,
+        long weeklyExpenseAmount,
         int weeklyClosetUsageRate
 ) {
 }

--- a/src/main/java/com/weartrack/backend/domain/home/service/HomeService.java
+++ b/src/main/java/com/weartrack/backend/domain/home/service/HomeService.java
@@ -1,0 +1,31 @@
+package com.weartrack.backend.domain.home.service;
+
+import com.weartrack.backend.domain.clothes.repository.ClothesRepository;
+import com.weartrack.backend.domain.home.dto.HomeSummaryResDto;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeService {
+
+    private static final int HARDCODED_WEEKLY_CLOSET_USAGE_RATE = 73;
+
+    private final ClothesRepository clothesRepository;
+
+    public HomeSummaryResDto getHomeSummary(Long memberId) {
+        LocalDateTime oneWeekAgo = LocalDateTime.now().minusDays(7);
+
+        int totalClothesCount = clothesRepository.countByMemberId(memberId);
+        int weeklyExpenseAmount = clothesRepository.sumWeeklyExpenseAmount(memberId, oneWeekAgo);
+
+        return new HomeSummaryResDto(
+                totalClothesCount,
+                weeklyExpenseAmount,
+                HARDCODED_WEEKLY_CLOSET_USAGE_RATE
+        );
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/home/service/HomeService.java
+++ b/src/main/java/com/weartrack/backend/domain/home/service/HomeService.java
@@ -19,8 +19,8 @@ public class HomeService {
     public HomeSummaryResDto getHomeSummary(Long memberId) {
         LocalDateTime oneWeekAgo = LocalDateTime.now().minusDays(7);
 
-        int totalClothesCount = clothesRepository.countByMemberId(memberId);
-        int weeklyExpenseAmount = clothesRepository.sumWeeklyExpenseAmount(memberId, oneWeekAgo);
+        long totalClothesCount = clothesRepository.countByMemberId(memberId);
+        long weeklyExpenseAmount = clothesRepository.sumWeeklyExpenseAmount(memberId, oneWeekAgo);
 
         return new HomeSummaryResDto(
                 totalClothesCount,


### PR DESCRIPTION
### 👀 관련 이슈

9

### ✨ 작업한 내용

- 사용자의 전체 옷 개수 조회
- 최근 1주일 기준 패션 소비 금액 합계 조회
- 옷장 활용률(%)은 MVP 기준으로 하드코딩 처리


### 📷 스크린샷 또는 GIF

<img width="871" height="424" alt="스크린샷 2026-04-29 223104" src="https://github.com/user-attachments/assets/095620ba-2b94-48aa-8c8b-894d2719ac51" />

<img width="844" height="494" alt="image" src="https://github.com/user-attachments/assets/1de6eb51-b069-4f11-8868-78a2a4312bfe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **홈 화면 요약 정보 조회**: 사용자의 전체 의류 보유 수량, 지난 일주일간의 의류 지출 금액, 주간 옷장 활용률 통계를 한눈에 확인할 수 있는 홈 요약 조회 기능이 추가되었습니다. 새로운 API 엔드포인트를 통해 개인화된 의류 관리 대시보드 정보를 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->