### PR TITLE
FIX: 파일 업로드 경로 설정 추가

### DIFF
--- a/src/main/java/com/weartrack/backend/domain/clothes/service/FileStorageService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/FileStorageService.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 @Service
 public class FileStorageService {
 
-    @Value("${file.upload-dir}")
+    @Value("${file.upload-dir:uploads}")
     private String uploadDir;
 
     public SavedFile save(MultipartFile image) {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -40,3 +40,6 @@ oauth:
     client-id: ${NAVER_CLIENT_ID}
     client-secret: ${NAVER_CLIENT_SECRET}
     redirect-uri: ${NAVER_REDIRECT_URI}
+
+file:
+  upload-dir: uploads


### PR DESCRIPTION
## 📌 작업 내용

메인 홈 조회 API 구현 및 리뷰 피드백을 반영했습니다.

---

## 🔧 수정 사항

### 파일 업로드 경로 설정 추가
- FileStorageService에서 사용하는 file.upload-dir 설정을 application-prod.yml에 추가
- 설정 누락 시에도 기본 uploads 경로를 사용하도록 fallback 처리

---
## 참고사항

현재는 로컬 파일 저장 방식을 사용하고 있어 file.upload-dir 설정을 추가했습니다.
추후 S3 저장 방식으로 전환할 경우 해당 설정은 S3 bucket/region/key 설정으로 대체될 예정입니다.