### PR TITLE
fix:옷, 옷장 사진 S3 업로드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	implementation platform('software.amazon.awssdk:bom:2.25.60')
+	implementation 'software.amazon.awssdk:s3'
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 }

--- a/src/main/java/com/weartrack/backend/domain/closet/service/ClosetPhotoService.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/service/ClosetPhotoService.java
@@ -3,7 +3,7 @@ package com.weartrack.backend.domain.closet.service;
 import com.weartrack.backend.domain.closet.dto.ClosetPhotoCreateResDto;
 import com.weartrack.backend.domain.closet.dto.PredictedSectionDto;
 import com.weartrack.backend.domain.closet.entity.ClosetTemplate;
-import com.weartrack.backend.domain.clothes.service.FileStorageService;
+import com.weartrack.backend.domain.clothes.service.S3StorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,13 +14,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ClosetPhotoService {
 
-    private final FileStorageService fileStorageService;
+    private final S3StorageService s3StorageService;
 
     public ClosetPhotoCreateResDto uploadClosetPhoto(Long memberId, Integer templateId, MultipartFile image) {
-        // TODO: S3 이미지 저장 및 옷장 사진 이력 저장 시 memberId 사용 예정
         ClosetTemplate template = ClosetTemplate.from(templateId);
 
-        FileStorageService.SavedFile savedFile = fileStorageService.saveCloset(image);
+        S3StorageService.SavedImage savedImage = s3StorageService.uploadClosetImage(image);
 
         List<PredictedSectionDto> predictedSections = template.getSectionOrders()
                 .stream()
@@ -30,7 +29,7 @@ public class ClosetPhotoService {
         return new ClosetPhotoCreateResDto(
                 "SUCCESS",
                 template.getTemplateId(),
-                savedFile.getImageUrl(),
+                savedImage.getImageUrl(),
                 template.getSectionCount(),
                 predictedSections
         );

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesAiClient.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesAiClient.java
@@ -46,7 +46,7 @@ public class ClothesAiClient {
                     .body(BodyInserters.fromMultipartData(body))
                     .retrieve()
                     .bodyToMono(AiClothesPredictionResponse.class)
-                    .block();
+                    .block(Duration.ofSeconds(40));
 
         } catch (IOException e) {
             throw new IllegalArgumentException("AI 서버로 전달할 이미지 파일을 읽는 중 오류가 발생했습니다.");

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesAiClient.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesAiClient.java
@@ -3,14 +3,17 @@ package com.weartrack.backend.domain.clothes.service;
 import com.weartrack.backend.domain.clothes.dto.AiClothesPredictionResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.File;
+import java.io.IOException;
 import java.time.Duration;
 
 @Component
@@ -22,20 +25,31 @@ public class ClothesAiClient {
     @Value("${ai.base-url}")
     private String aiBaseUrl;
 
-    public AiClothesPredictionResponse predict(File imageFile) {
-        LinkedMultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-        body.add("file", new FileSystemResource(imageFile));
+    public AiClothesPredictionResponse predict(MultipartFile image) {
+        try {
+            ByteArrayResource imageResource = new ByteArrayResource(image.getBytes()) {
+                @Override
+                public String getFilename() {
+                    return image.getOriginalFilename();
+                }
+            };
 
-        return webClientBuilder
-                .baseUrl(aiBaseUrl)
-                .build()
-                .post()
-                .uri("/predict-clothes")
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .body(BodyInserters.fromMultipartData(body))
-                .retrieve()
-                .bodyToMono(AiClothesPredictionResponse.class)
-                .timeout(Duration.ofSeconds(40))
-                .block();
+            LinkedMultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            body.add("file", imageResource);
+
+            return webClientBuilder
+                    .baseUrl(aiBaseUrl)
+                    .build()
+                    .post()
+                    .uri("/predict-clothes")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(BodyInserters.fromMultipartData(body))
+                    .retrieve()
+                    .bodyToMono(AiClothesPredictionResponse.class)
+                    .block();
+
+        } catch (IOException e) {
+            throw new IllegalArgumentException("AI 서버로 전달할 이미지 파일을 읽는 중 오류가 발생했습니다.");
+        }
     }
 }

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesPhotoService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesPhotoService.java
@@ -59,7 +59,11 @@ public class ClothesPhotoService {
             );
 
         } catch (Exception e) {
-            s3StorageService.delete(savedImage.getKey());
+            try {
+                s3StorageService.delete(savedImage.getKey());
+            } catch (Exception cleanupException) {
+                e.addSuppressed(cleanupException);
+            }
             throw e;
         }
     }

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesPhotoService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesPhotoService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
 import java.util.List;
 
 @Service
@@ -20,17 +19,16 @@ import java.util.List;
 @Transactional
 public class ClothesPhotoService {
 
-    private final FileStorageService fileStorageService;
+    private final S3StorageService s3StorageService;
     private final ClothesAiClient clothesAiClient;
     private final ClothesPhotoRepository clothesPhotoRepository;
 
     public ClothesPhotoCreateResponse uploadAndAnalyze(Long memberId, MultipartFile image) {
 
-        FileStorageService.SavedFile savedFile = fileStorageService.save(image);
+        S3StorageService.SavedImage savedImage = s3StorageService.uploadClothesImage(image);
 
         try {
-            AiClothesPredictionResponse aiResult =
-                    clothesAiClient.predict(savedFile.getFile());
+            AiClothesPredictionResponse aiResult = clothesAiClient.predict(image);
 
             if (aiResult == null || aiResult.results() == null || aiResult.results().isEmpty()) {
                 throw new IllegalStateException("AI 분석 결과가 없습니다.");
@@ -44,7 +42,7 @@ public class ClothesPhotoService {
 
             ClothesPhoto clothesPhoto = ClothesPhoto.builder()
                     .memberId(memberId)
-                    .imageUrl(savedFile.getImageUrl())
+                    .imageUrl(savedImage.getImageUrl())
                     .analysisStatus(AnalysisStatus.SUCCESS)
                     .predictedCategory(predictedCategory)
                     .predictedColor(predictedColor)
@@ -61,14 +59,8 @@ public class ClothesPhotoService {
             );
 
         } catch (Exception e) {
-            deleteFileIfExists(savedFile.getFile());
+            s3StorageService.delete(savedImage.getKey());
             throw e;
-        }
-    }
-
-    private void deleteFileIfExists(File file) {
-        if (file != null && file.exists()) {
-            file.delete();
         }
     }
 }

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/S3StorageService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/S3StorageService.java
@@ -23,7 +23,7 @@ public class S3StorageService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    @Value("${cloud.aws.region.static}")
+    @Value("${cloud.aws.region}")
     private String region;
 
     public SavedImage uploadClothesImage(MultipartFile image) {
@@ -38,7 +38,7 @@ public class S3StorageService {
         validateImage(image);
 
         String originalFilename = image.getOriginalFilename();
-        String extension = getExtension(originalFilename);
+        String extension = getExtension(originalFilename, image.getContentType());
         String key = dirName + "/" + UUID.randomUUID() + extension;
 
         try {
@@ -89,21 +89,33 @@ public class S3StorageService {
         }
     }
 
-    private String getExtension(String filename) {
-        if (filename == null || !filename.contains(".")) {
-            return ".jpg";
-        }
+    private String getExtension(String filename, String contentType) {
+        if (filename != null && filename.contains(".")) {
+            String extension = filename.substring(filename.lastIndexOf(".")).toLowerCase();
 
-        String extension = filename.substring(filename.lastIndexOf(".")).toLowerCase();
+            if (extension.equals(".jpg")
+                    || extension.equals(".jpeg")
+                    || extension.equals(".png")
+                    || extension.equals(".webp")) {
+                return extension;
+            }
 
-        if (!extension.equals(".jpg")
-                && !extension.equals(".jpeg")
-                && !extension.equals(".png")
-                && !extension.equals(".webp")) {
             throw new IllegalArgumentException("허용되지 않는 이미지 확장자입니다.");
         }
 
-        return extension;
+        if ("image/jpeg".equals(contentType)) {
+            return ".jpg";
+        }
+
+        if ("image/png".equals(contentType)) {
+            return ".png";
+        }
+
+        if ("image/webp".equals(contentType)) {
+            return ".webp";
+        }
+
+        throw new IllegalArgumentException("이미지 확장자를 확인할 수 없습니다.");
     }
 
     @Getter

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/S3StorageService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/S3StorageService.java
@@ -1,0 +1,119 @@
+package com.weartrack.backend.domain.clothes.service;
+
+import com.weartrack.backend.domain.closet.exception.ClosetErrorCode;
+import com.weartrack.backend.global.exception.GeneralException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3StorageService {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public SavedImage uploadClothesImage(MultipartFile image) {
+        return upload(image, "clothes");
+    }
+
+    public SavedImage uploadClosetImage(MultipartFile image) {
+        return upload(image, "closets");
+    }
+
+    private SavedImage upload(MultipartFile image, String dirName) {
+        validateImage(image);
+
+        String originalFilename = image.getOriginalFilename();
+        String extension = getExtension(originalFilename);
+        String key = dirName + "/" + UUID.randomUUID() + extension;
+
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(image.getContentType())
+                    .contentLength(image.getSize())
+                    .build();
+
+            s3Client.putObject(
+                    request,
+                    RequestBody.fromInputStream(image.getInputStream(), image.getSize())
+            );
+
+            String imageUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + key;
+
+            return new SavedImage(key, imageUrl);
+
+        } catch (IOException e) {
+            throw new IllegalArgumentException("이미지 업로드 중 오류가 발생했습니다.");
+        }
+    }
+
+    public void delete(String key) {
+        if (key == null || key.isBlank()) {
+            return;
+        }
+
+        s3Client.deleteObject(builder -> builder
+                .bucket(bucket)
+                .key(key)
+                .build());
+    }
+
+    private void validateImage(MultipartFile image) {
+        if (image == null || image.isEmpty()) {
+            throw new IllegalArgumentException("이미지 파일은 필수입니다.");
+        }
+
+        String contentType = image.getContentType();
+
+        if (contentType == null ||
+                !(contentType.equals("image/jpeg")
+                        || contentType.equals("image/png")
+                        || contentType.equals("image/webp"))) {
+            throw new IllegalArgumentException("이미지 파일은 JPG, PNG, WebP 형식만 업로드할 수 있습니다.");
+        }
+    }
+
+    private String getExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            return ".jpg";
+        }
+
+        String extension = filename.substring(filename.lastIndexOf(".")).toLowerCase();
+
+        if (!extension.equals(".jpg")
+                && !extension.equals(".jpeg")
+                && !extension.equals(".png")
+                && !extension.equals(".webp")) {
+            throw new IllegalArgumentException("허용되지 않는 이미지 확장자입니다.");
+        }
+
+        return extension;
+    }
+
+    @Getter
+    public static class SavedImage {
+        private final String key;
+        private final String imageUrl;
+
+        public SavedImage(String key, String imageUrl) {
+            this.key = key;
+            this.imageUrl = imageUrl;
+        }
+    }
+}

--- a/src/main/java/com/weartrack/backend/global/config/S3Config.java
+++ b/src/main/java/com/weartrack/backend/global/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.weartrack.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/weartrack/backend/global/config/S3Config.java
+++ b/src/main/java/com/weartrack/backend/global/config/S3Config.java
@@ -11,7 +11,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Configuration
 public class S3Config {
 
-    @Value("${cloud.aws.region.static}")
+    @Value("${cloud.aws.region}")
     private String region;
 
     @Value("${cloud.aws.credentials.access-key}")

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -43,3 +43,15 @@ oauth:
 
 file:
   upload-dir: uploads
+
+cloud:
+   aws:
+     region: ${AWS_REGION:ap-northeast-2}
+     s3:
+       bucket: ${AWS_S3_BUCKET}
+     credentials:
+       access-key: ${AWS_ACCESS_KEY}
+       secret-key: ${AWS_SECRET_KEY}
+
+ai:
+  base-url: ${AI_BASE_URL}


### PR DESCRIPTION
### 👀 관련 이슈

11

### ✨ 작업한 내용

- 옷/옷장 사진 업로드 API 구현
- S3StorageService를 활용한 이미지 업로드 처리
- 업로드된 옷장 사진 URL 반환 로직 추가
- AWS S3 설정값을 환경변수 기반으로 분리

## 테스트
- local profile 실행 확인
- S3 환경변수 설정 후 애플리케이션 정상 실행 확인
- Swagger 테스트 시 CORS 설정 이슈 확인

## 참고
- AWS 키, 버킷명 등 민감정보는 yml에 직접 포함하지 않고 환경변수로 관리.
- 현재 Swagger 배포 도메인 테스트 시 403 Invalid CORS request가 발생하여 prod CORS 설정에 `https://wear-track.com` 추가가 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **신규 기능**
  * AWS S3를 통한 이미지 저장소 통합으로 안정적인 클라우드 기반 이미지 관리 구현
  * 의류 및 옷장 사진 업로드 기능이 S3로 업그레이드

* **개선사항**
  * 이미지 검증 및 처리 프로세스 강화 (JPEG, PNG, WebP 지원)
  * 다중 파일 업로드 방식 현대화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->