### PR TITLE
Fix: Swagger CORS 403 오류 수정

### DIFF
--- a/src/main/java/com/weartrack/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/weartrack/backend/global/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    @Value("${app.cors.allowed-origins:http://localhost:3000,https://weartrack.co.kr}")
+    @Value("${app.cors.allowed-origins:http://localhost:3000,https://wear-track.com,https://weartrack.co.kr}")
     private List<String> allowedOrigins;
 
     /**

--- a/src/main/java/com/weartrack/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/weartrack/backend/global/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    @Value("${app.cors.allowed-origins:http://localhost:3000,https://wear-track.com,https://weartrack.co.kr}")
+    @Value("${app.cors.allowed-origins:https://wear-track.com,https://weartrack.co.kr}")
     private List<String> allowedOrigins;
 
     /**

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,7 +21,7 @@ jwt:
 
 app:
   cors:
-    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:3000,https://weartrack.co.kr}
+    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:3000,https://wear-track.com,https://weartrack.co.kr}
 
 # OAuth 클라이언트 설정은 실행 환경의 환경변수에서 주입합니다.
 oauth:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,7 +21,7 @@ jwt:
 
 app:
   cors:
-    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:3000,https://wear-track.com,https://weartrack.co.kr}
+    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:https://wear-track.com,https://weartrack.co.kr}
 
 # OAuth 클라이언트 설정은 실행 환경의 환경변수에서 주입합니다.
 oauth:


### PR DESCRIPTION
- Swagger API 테스트 시 wear-track.com 요청이 CORS 403으로 차단되던 문제 수정
- allowed origins 기본값에 https://wear-track.com 추가
- SecurityConfig와 application-prod.yml의 기본값 일치시킴

### 👀 관련 이슈

- Swagger UI에서 API 테스트 시 `Invalid CORS request`로 403 응답 발생

### ✨ 작업한 내용

- Swagger API 테스트 시 `wear-track.com` 요청이 CORS 403으로 차단되던 문제 수정
- allowed origins 기본값에 `https://wear-track.com` 추가
- `SecurityConfig`와 `application-prod.yml`의 CORS 기본값 일치시킴

### 🌀 PR Point

- 운영 Swagger 호출 도메인과 CORS 허용 도메인이 달라 발생한 문제 수정
- 환경변수가 없을 때 사용되는 기본값 기준으로 수정함

### 🍰 참고사항
- 운영 환경에서 `APP_CORS_ALLOWED_ORIGINS`를 별도로 사용 중이면 해당 값도 동일하게 맞춰야 함
- 현재 수정만으로는 기본 설정 기준 `https://wear-track.com` 요청 허용 가능

### 📷 스크린샷 또는 GIF

없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CORS 구성이 업데이트되어 새로운 도메인에서의 애플리케이션 접근이 허용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->