### PR TITLE
fix: S3 설정 오류 및 파일 업로드 용량 제한 수정

### DIFF
--- a/src/main/java/com/weartrack/backend/domain/clothes/service/S3StorageService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/S3StorageService.java
@@ -23,7 +23,7 @@ public class S3StorageService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    @Value("${cloud.aws.region}")
+    @Value("${cloud.aws.region.static}")
     private String region;
 
     public SavedImage uploadClothesImage(MultipartFile image) {

--- a/src/main/java/com/weartrack/backend/global/config/S3Config.java
+++ b/src/main/java/com/weartrack/backend/global/config/S3Config.java
@@ -11,7 +11,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Configuration
 public class S3Config {
 
-    @Value("${cloud.aws.region}")
+    @Value("${cloud.aws.region.static}")
     private String region;
 
     @Value("${cloud.aws.credentials.access-key}")

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,6 +5,11 @@ spring:
     username: ${DB_USER} # MySQL 사용자명입니다.
     password: ${DB_PW} # MySQL 비밀번호입니다.
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   jpa:
     database: mysql # 사용하는 데이터베이스 타입입니다.
     database-platform: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## 📌 작업 내용
- S3 설정에서 cloud.aws.region key mismatch 수정
- multipart 파일 업로드 용량 제한 설정 추가 (10MB)

## 🔧 변경 사항
- cloud.aws.region → cloud.aws.region.static로 수정
- application-local.yml / application-prod.yml에 multipart 설정 추가

## 🚨 문제 해결
- S3 Bean 생성 실패 (UnsatisfiedDependencyException) 해결
- 이미지 업로드 시 FileSizeLimitExceededException 해결

## ✅ 결과
- 로컬  환경에서 정상 업로드 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * AWS 리전 설정 프로퍼티 업데이트

* **Bug Fixes**
  * 파일 업로드 크기 제한 설정 (개별 파일 및 전체 요청 크기 10MB로 제한)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->