### PR TITLE
Feat: 모바일 OAuth 브릿지 플로우 추가

### DIFF
--- a/src/main/java/com/weartrack/backend/domain/member/constant/AuthClientType.java
+++ b/src/main/java/com/weartrack/backend/domain/member/constant/AuthClientType.java
@@ -1,0 +1,6 @@
+package com.weartrack.backend.domain.member.constant;
+
+public enum AuthClientType {
+    WEB,
+    MOBILE
+}

--- a/src/main/java/com/weartrack/backend/domain/member/controller/AuthController.java
+++ b/src/main/java/com/weartrack/backend/domain/member/controller/AuthController.java
@@ -1,17 +1,27 @@
 package com.weartrack.backend.domain.member.controller;
 
+import com.weartrack.backend.domain.member.constant.AuthClientType;
 import com.weartrack.backend.domain.member.constant.AuthProvider;
+import com.weartrack.backend.domain.member.dto.OAuthStatePayload;
 import com.weartrack.backend.domain.member.dto.request.SocialLoginReqDto;
 import com.weartrack.backend.domain.member.dto.response.SocialLoginResDto;
 import com.weartrack.backend.domain.member.service.AuthService;
+import com.weartrack.backend.domain.member.service.OAuthHandoffService;
+import com.weartrack.backend.domain.member.service.OAuthStateService;
+import com.weartrack.backend.domain.member.service.SocialOAuthAuthorizeService;
 import com.weartrack.backend.global.response.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseCookie;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -25,6 +35,23 @@ public class AuthController {
     private static final String OAUTH_STATE_COOKIE_NAME = "oauth-login-state";
 
     private final AuthService authService;
+    private final OAuthHandoffService oAuthHandoffService;
+    private final OAuthStateService oAuthStateService;
+    private final SocialOAuthAuthorizeService socialOAuthAuthorizeService;
+
+    @Value("${app.oauth.mobile.callback-base-uri:weartrack://auth/callback}")
+    private String mobileCallbackBaseUri;
+
+    @GetMapping("/api/auth/social/authorize/{provider}")
+    public ResponseEntity<Void> authorize(
+            @PathVariable String provider,
+            @RequestParam(name = "client", defaultValue = "MOBILE") AuthClientType clientType
+    ) {
+        AuthProvider authProvider = AuthProvider.valueOf(provider.toUpperCase());
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(socialOAuthAuthorizeService.buildAuthorizeUri(authProvider, clientType))
+                .build();
+    }
 
 
     /**
@@ -48,23 +75,13 @@ public class AuthController {
      * Google 로그인 완료 후 전달된 인가 코드를 바로 처리합니다.
      */
     @GetMapping("/login/oauth2/code/google")
-    public ApiResponse<SocialLoginResDto> googleCallback(
+    public ResponseEntity<?> googleCallback(
             @RequestParam("code") String code,
             @RequestParam("state") String state,
             HttpServletRequest httpRequest,
             HttpServletResponse httpResponse
     ) {
-        try {
-            SocialLoginResDto response = authService.login(
-                    AuthProvider.GOOGLE,
-                    code,
-                    state,
-                    extractOAuthState(httpRequest)
-            );
-            return ApiResponse.success(response);
-        } finally {
-            expireOAuthStateCookie(httpResponse);
-        }
+        return handleCallback(AuthProvider.GOOGLE, code, state, httpRequest, httpResponse);
     }
 
 
@@ -72,23 +89,13 @@ public class AuthController {
      * Kakao 로그인 완료 후 전달된 인가 코드를 바로 처리합니다.
      */
     @GetMapping("/login/oauth2/code/kakao")
-    public ApiResponse<SocialLoginResDto> kakaoCallback(
+    public ResponseEntity<?> kakaoCallback(
             @RequestParam("code") String code,
             @RequestParam("state") String state,
             HttpServletRequest httpRequest,
             HttpServletResponse httpResponse
     ) {
-        try {
-            SocialLoginResDto response = authService.login(
-                    AuthProvider.KAKAO,
-                    code,
-                    state,
-                    extractOAuthState(httpRequest)
-            );
-            return ApiResponse.success(response);
-        } finally {
-            expireOAuthStateCookie(httpResponse);
-        }
+        return handleCallback(AuthProvider.KAKAO, code, state, httpRequest, httpResponse);
     }
 
 
@@ -96,23 +103,52 @@ public class AuthController {
      * Naver 로그인 완료 후 전달된 인가 코드와 state를 바로 처리합니다.
      */
     @GetMapping("/login/oauth2/code/naver")
-    public ApiResponse<SocialLoginResDto> naverCallback(
+    public ResponseEntity<?> naverCallback(
             @RequestParam("code") String code,
             @RequestParam("state") String state,
             HttpServletRequest httpRequest,
             HttpServletResponse httpResponse
     ) {
+        return handleCallback(AuthProvider.NAVER, code, state, httpRequest, httpResponse);
+    }
+
+    private ResponseEntity<?> handleCallback(
+            AuthProvider provider,
+            String code,
+            String state,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse
+    ) {
         try {
+            var managedState = oAuthStateService.consumeIfPresent(provider, state);
+            if (managedState.isPresent()) {
+                OAuthStatePayload statePayload = managedState.get();
+                if (statePayload.clientType() == AuthClientType.MOBILE) {
+                    String handoffToken = oAuthHandoffService.create(provider, code, state);
+                    return ResponseEntity.status(HttpStatus.FOUND)
+                            .location(buildMobileCallbackUri(provider, handoffToken))
+                            .build();
+                }
+            }
+
             SocialLoginResDto response = authService.login(
-                    AuthProvider.NAVER,
+                    provider,
                     code,
                     state,
                     extractOAuthState(httpRequest)
             );
-            return ApiResponse.success(response);
+            return ResponseEntity.ok(ApiResponse.success(response));
         } finally {
             expireOAuthStateCookie(httpResponse);
         }
+    }
+
+    private URI buildMobileCallbackUri(AuthProvider provider, String handoffToken) {
+        return URI.create("%s/%s?handoff=%s".formatted(
+                mobileCallbackBaseUri,
+                provider.name().toLowerCase(),
+                handoffToken
+        ));
     }
 
     private String extractOAuthState(HttpServletRequest request) {

--- a/src/main/java/com/weartrack/backend/domain/member/controller/AuthController.java
+++ b/src/main/java/com/weartrack/backend/domain/member/controller/AuthController.java
@@ -129,6 +129,13 @@ public class AuthController {
                             .location(buildMobileCallbackUri(provider, handoffToken))
                             .build();
                 }
+
+                SocialLoginResDto response = authService.login(
+                        provider,
+                        code,
+                        state
+                );
+                return ResponseEntity.ok(ApiResponse.success(response));
             }
 
             SocialLoginResDto response = authService.login(

--- a/src/main/java/com/weartrack/backend/domain/member/dto/OAuthHandoffPayload.java
+++ b/src/main/java/com/weartrack/backend/domain/member/dto/OAuthHandoffPayload.java
@@ -1,0 +1,10 @@
+package com.weartrack.backend.domain.member.dto;
+
+import com.weartrack.backend.domain.member.constant.AuthProvider;
+
+public record OAuthHandoffPayload(
+        AuthProvider provider,
+        String authorizationCode,
+        String state
+) {
+}

--- a/src/main/java/com/weartrack/backend/domain/member/dto/OAuthStatePayload.java
+++ b/src/main/java/com/weartrack/backend/domain/member/dto/OAuthStatePayload.java
@@ -1,0 +1,10 @@
+package com.weartrack.backend.domain.member.dto;
+
+import com.weartrack.backend.domain.member.constant.AuthClientType;
+import com.weartrack.backend.domain.member.constant.AuthProvider;
+
+public record OAuthStatePayload(
+        AuthProvider provider,
+        AuthClientType clientType
+) {
+}

--- a/src/main/java/com/weartrack/backend/domain/member/dto/request/SocialLoginReqDto.java
+++ b/src/main/java/com/weartrack/backend/domain/member/dto/request/SocialLoginReqDto.java
@@ -1,7 +1,6 @@
 package com.weartrack.backend.domain.member.dto.request;
 
 import com.weartrack.backend.domain.member.constant.AuthProvider;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 /**
@@ -11,9 +10,10 @@ public record SocialLoginReqDto(
         @NotNull
         AuthProvider provider,
 
-        @NotBlank
         String authorizationCode,
 
-        String state
+        String state,
+
+        String handoffToken
 ) {
 }

--- a/src/main/java/com/weartrack/backend/domain/member/exception/AuthErrorCode.java
+++ b/src/main/java/com/weartrack/backend/domain/member/exception/AuthErrorCode.java
@@ -13,6 +13,8 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements BaseErrorCode {
     UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "AUTH_400_1", "Unsupported social provider."),
     INVALID_OAUTH_STATE(HttpStatus.BAD_REQUEST, "AUTH_400_2", "Invalid OAuth state."),
+    INVALID_SOCIAL_LOGIN_REQUEST(HttpStatus.BAD_REQUEST, "AUTH_400_3", "Invalid social login request."),
+    INVALID_OAUTH_HANDOFF(HttpStatus.BAD_REQUEST, "AUTH_400_4", "Invalid OAuth handoff token."),
     INVALID_SOCIAL_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_1", "Invalid social access token."),
     SOCIAL_USER_INFO_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_401_2", "Failed to load social user information."),
     INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_3", "Invalid JWT token.");

--- a/src/main/java/com/weartrack/backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/weartrack/backend/domain/member/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.weartrack.backend.domain.member.service;
 
 import com.weartrack.backend.domain.member.constant.AuthProvider;
+import com.weartrack.backend.domain.member.dto.OAuthHandoffPayload;
 import com.weartrack.backend.domain.member.dto.SocialUserInfo;
 import com.weartrack.backend.domain.member.dto.request.SocialLoginReqDto;
 import com.weartrack.backend.domain.member.dto.response.SocialLoginResDto;
@@ -19,16 +20,32 @@ public class AuthService {
 
     private final Map<AuthProvider, SocialLoginProviderClient> providerClients;
     private final AuthLoginTransactionService authLoginTransactionService;
+    private final OAuthHandoffService oAuthHandoffService;
 
     public AuthService(
             List<SocialLoginProviderClient> providerClients,
-            AuthLoginTransactionService authLoginTransactionService
+            AuthLoginTransactionService authLoginTransactionService,
+            OAuthHandoffService oAuthHandoffService
     ) {
         this.providerClients = mapProviderClients(providerClients);
         this.authLoginTransactionService = authLoginTransactionService;
+        this.oAuthHandoffService = oAuthHandoffService;
     }
 
     public SocialLoginResDto login(SocialLoginReqDto request) {
+        if (StringUtils.hasText(request.handoffToken())) {
+            OAuthHandoffPayload handoffPayload = oAuthHandoffService.consume(request.provider(), request.handoffToken());
+            return loginInternal(
+                    handoffPayload.provider(),
+                    handoffPayload.authorizationCode(),
+                    handoffPayload.state()
+            );
+        }
+
+        if (!StringUtils.hasText(request.authorizationCode())) {
+            throw new GeneralException(AuthErrorCode.INVALID_SOCIAL_LOGIN_REQUEST);
+        }
+
         return loginInternal(request.provider(), request.authorizationCode(), request.state());
     }
 

--- a/src/main/java/com/weartrack/backend/domain/member/service/OAuthHandoffService.java
+++ b/src/main/java/com/weartrack/backend/domain/member/service/OAuthHandoffService.java
@@ -27,6 +27,9 @@ public class OAuthHandoffService {
     }
 
     OAuthHandoffService(Duration ttl, Clock clock) {
+        if (ttl == null || ttl.isZero() || ttl.isNegative()) {
+            throw new IllegalArgumentException("app.oauth.mobile.handoff-ttl-seconds must be positive");
+        }
         this.ttl = ttl;
         this.clock = clock;
     }

--- a/src/main/java/com/weartrack/backend/domain/member/service/OAuthHandoffService.java
+++ b/src/main/java/com/weartrack/backend/domain/member/service/OAuthHandoffService.java
@@ -1,0 +1,74 @@
+package com.weartrack.backend.domain.member.service;
+
+import com.weartrack.backend.domain.member.constant.AuthProvider;
+import com.weartrack.backend.domain.member.dto.OAuthHandoffPayload;
+import com.weartrack.backend.domain.member.exception.AuthErrorCode;
+import com.weartrack.backend.global.exception.GeneralException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OAuthHandoffService {
+
+    private final Map<String, StoredOAuthHandoff> handoffs = new ConcurrentHashMap<>();
+    private final Duration ttl;
+    private final Clock clock;
+
+    public OAuthHandoffService(
+            @Value("${app.oauth.mobile.handoff-ttl-seconds:180}") long handoffTtlSeconds
+    ) {
+        this(Duration.ofSeconds(handoffTtlSeconds), Clock.systemUTC());
+    }
+
+    OAuthHandoffService(Duration ttl, Clock clock) {
+        this.ttl = ttl;
+        this.clock = clock;
+    }
+
+    public String create(AuthProvider provider, String authorizationCode, String state) {
+        purgeExpired();
+
+        String token = UUID.randomUUID().toString();
+        Instant expiresAt = clock.instant().plus(ttl);
+        handoffs.put(token, new StoredOAuthHandoff(
+                new OAuthHandoffPayload(provider, authorizationCode, state),
+                expiresAt
+        ));
+        return token;
+    }
+
+    public OAuthHandoffPayload consume(AuthProvider provider, String token) {
+        purgeExpired();
+
+        StoredOAuthHandoff handoff = handoffs.remove(token);
+        if (handoff == null || handoff.isExpired(clock.instant())) {
+            throw new GeneralException(AuthErrorCode.INVALID_OAUTH_HANDOFF);
+        }
+
+        if (handoff.payload().provider() != provider) {
+            throw new GeneralException(AuthErrorCode.INVALID_OAUTH_HANDOFF);
+        }
+
+        return handoff.payload();
+    }
+
+    private void purgeExpired() {
+        Instant now = clock.instant();
+        handoffs.entrySet().removeIf(entry -> entry.getValue().isExpired(now));
+    }
+
+    private record StoredOAuthHandoff(
+            OAuthHandoffPayload payload,
+            Instant expiresAt
+    ) {
+        private boolean isExpired(Instant now) {
+            return !expiresAt.isAfter(now);
+        }
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/member/service/OAuthStateService.java
+++ b/src/main/java/com/weartrack/backend/domain/member/service/OAuthStateService.java
@@ -1,0 +1,75 @@
+package com.weartrack.backend.domain.member.service;
+
+import com.weartrack.backend.domain.member.constant.AuthClientType;
+import com.weartrack.backend.domain.member.constant.AuthProvider;
+import com.weartrack.backend.domain.member.dto.OAuthStatePayload;
+import com.weartrack.backend.domain.member.exception.AuthErrorCode;
+import com.weartrack.backend.global.exception.GeneralException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OAuthStateService {
+
+    private final Map<String, StoredOAuthState> states = new ConcurrentHashMap<>();
+    private final Duration ttl;
+    private final Clock clock;
+
+    public OAuthStateService(
+            @Value("${app.oauth.state-ttl-seconds:300}") long stateTtlSeconds
+    ) {
+        this(Duration.ofSeconds(stateTtlSeconds), Clock.systemUTC());
+    }
+
+    OAuthStateService(Duration ttl, Clock clock) {
+        this.ttl = ttl;
+        this.clock = clock;
+    }
+
+    public String create(AuthProvider provider, AuthClientType clientType) {
+        purgeExpired();
+
+        String state = UUID.randomUUID().toString();
+        states.put(state, new StoredOAuthState(
+                new OAuthStatePayload(provider, clientType),
+                clock.instant().plus(ttl)
+        ));
+        return state;
+    }
+
+    public Optional<OAuthStatePayload> consumeIfPresent(AuthProvider provider, String state) {
+        purgeExpired();
+
+        StoredOAuthState storedState = states.remove(state);
+        if (storedState == null || storedState.isExpired(clock.instant())) {
+            return Optional.empty();
+        }
+
+        if (storedState.payload().provider() != provider) {
+            throw new GeneralException(AuthErrorCode.INVALID_OAUTH_STATE);
+        }
+
+        return Optional.of(storedState.payload());
+    }
+
+    private void purgeExpired() {
+        Instant now = clock.instant();
+        states.entrySet().removeIf(entry -> entry.getValue().isExpired(now));
+    }
+
+    private record StoredOAuthState(
+            OAuthStatePayload payload,
+            Instant expiresAt
+    ) {
+        private boolean isExpired(Instant now) {
+            return !expiresAt.isAfter(now);
+        }
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/member/service/OAuthStateService.java
+++ b/src/main/java/com/weartrack/backend/domain/member/service/OAuthStateService.java
@@ -29,6 +29,9 @@ public class OAuthStateService {
     }
 
     OAuthStateService(Duration ttl, Clock clock) {
+        if (ttl == null || ttl.isZero() || ttl.isNegative()) {
+            throw new IllegalArgumentException("app.oauth.state-ttl-seconds must be positive");
+        }
         this.ttl = ttl;
         this.clock = clock;
     }

--- a/src/main/java/com/weartrack/backend/domain/member/service/SocialOAuthAuthorizeService.java
+++ b/src/main/java/com/weartrack/backend/domain/member/service/SocialOAuthAuthorizeService.java
@@ -61,7 +61,8 @@ public class SocialOAuthAuthorizeService {
                     .queryParam("response_type", "code")
                     .queryParam("scope", googleScope)
                     .queryParam("state", state)
-                    .build(false)
+                    .build()
+                    .encode()
                     .toUri();
             case KAKAO -> UriComponentsBuilder.fromUriString(KAKAO_AUTHORIZE_URI)
                     .queryParam("client_id", kakaoClientId)
@@ -69,7 +70,8 @@ public class SocialOAuthAuthorizeService {
                     .queryParam("response_type", "code")
                     .queryParam("scope", kakaoScope)
                     .queryParam("state", state)
-                    .build(false)
+                    .build()
+                    .encode()
                     .toUri();
             case NAVER -> UriComponentsBuilder.fromUriString(NAVER_AUTHORIZE_URI)
                     .queryParam("client_id", naverClientId)
@@ -77,7 +79,8 @@ public class SocialOAuthAuthorizeService {
                     .queryParam("response_type", "code")
                     .queryParam("scope", naverScope)
                     .queryParam("state", state)
-                    .build(false)
+                    .build()
+                    .encode()
                     .toUri();
             default -> throw new GeneralException(AuthErrorCode.UNSUPPORTED_PROVIDER);
         };

--- a/src/main/java/com/weartrack/backend/domain/member/service/SocialOAuthAuthorizeService.java
+++ b/src/main/java/com/weartrack/backend/domain/member/service/SocialOAuthAuthorizeService.java
@@ -1,0 +1,85 @@
+package com.weartrack.backend.domain.member.service;
+
+import com.weartrack.backend.domain.member.constant.AuthClientType;
+import com.weartrack.backend.domain.member.constant.AuthProvider;
+import com.weartrack.backend.domain.member.exception.AuthErrorCode;
+import com.weartrack.backend.global.exception.GeneralException;
+import java.net.URI;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+public class SocialOAuthAuthorizeService {
+
+    private static final String GOOGLE_AUTHORIZE_URI = "https://accounts.google.com/o/oauth2/v2/auth";
+    private static final String KAKAO_AUTHORIZE_URI = "https://kauth.kakao.com/oauth/authorize";
+    private static final String NAVER_AUTHORIZE_URI = "https://nid.naver.com/oauth2.0/authorize";
+
+    private final OAuthStateService oAuthStateService;
+    private final String googleClientId;
+    private final String googleRedirectUri;
+    private final String googleScope;
+    private final String kakaoClientId;
+    private final String kakaoRedirectUri;
+    private final String kakaoScope;
+    private final String naverClientId;
+    private final String naverRedirectUri;
+    private final String naverScope;
+
+    public SocialOAuthAuthorizeService(
+            OAuthStateService oAuthStateService,
+            @Value("${GOOGLE_CLIENT_ID}") String googleClientId,
+            @Value("${GOOGLE_REDIRECT_URI}") String googleRedirectUri,
+            @Value("${oauth.google.scope:openid email profile}") String googleScope,
+            @Value("${KAKAO_CLIENT_ID}") String kakaoClientId,
+            @Value("${KAKAO_REDIRECT_URI}") String kakaoRedirectUri,
+            @Value("${oauth.kakao.scope:account_email}") String kakaoScope,
+            @Value("${NAVER_CLIENT_ID}") String naverClientId,
+            @Value("${NAVER_REDIRECT_URI}") String naverRedirectUri,
+            @Value("${oauth.naver.scope:name email}") String naverScope
+    ) {
+        this.oAuthStateService = oAuthStateService;
+        this.googleClientId = googleClientId;
+        this.googleRedirectUri = googleRedirectUri;
+        this.googleScope = googleScope;
+        this.kakaoClientId = kakaoClientId;
+        this.kakaoRedirectUri = kakaoRedirectUri;
+        this.kakaoScope = kakaoScope;
+        this.naverClientId = naverClientId;
+        this.naverRedirectUri = naverRedirectUri;
+        this.naverScope = naverScope;
+    }
+
+    public URI buildAuthorizeUri(AuthProvider provider, AuthClientType clientType) {
+        String state = oAuthStateService.create(provider, clientType);
+
+        return switch (provider) {
+            case GOOGLE -> UriComponentsBuilder.fromUriString(GOOGLE_AUTHORIZE_URI)
+                    .queryParam("client_id", googleClientId)
+                    .queryParam("redirect_uri", googleRedirectUri)
+                    .queryParam("response_type", "code")
+                    .queryParam("scope", googleScope)
+                    .queryParam("state", state)
+                    .build(false)
+                    .toUri();
+            case KAKAO -> UriComponentsBuilder.fromUriString(KAKAO_AUTHORIZE_URI)
+                    .queryParam("client_id", kakaoClientId)
+                    .queryParam("redirect_uri", kakaoRedirectUri)
+                    .queryParam("response_type", "code")
+                    .queryParam("scope", kakaoScope)
+                    .queryParam("state", state)
+                    .build(false)
+                    .toUri();
+            case NAVER -> UriComponentsBuilder.fromUriString(NAVER_AUTHORIZE_URI)
+                    .queryParam("client_id", naverClientId)
+                    .queryParam("redirect_uri", naverRedirectUri)
+                    .queryParam("response_type", "code")
+                    .queryParam("scope", naverScope)
+                    .queryParam("state", state)
+                    .build(false)
+                    .toUri();
+            default -> throw new GeneralException(AuthErrorCode.UNSUPPORTED_PROVIDER);
+        };
+    }
+}

--- a/src/main/java/com/weartrack/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/weartrack/backend/global/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/",
                                 "/index.html",
+                                "/api/auth/social/authorize/*",
                                 "/api/auth/social/login",
                                 "/login/oauth2/code/google",
                                 "/login/oauth2/code/kakao",

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -22,6 +22,11 @@ jwt:
 app:
   cors:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:https://wear-track.com,https://weartrack.co.kr}
+  oauth:
+    state-ttl-seconds: ${APP_OAUTH_STATE_TTL_SECONDS:300}
+    mobile:
+      callback-base-uri: ${APP_OAUTH_MOBILE_CALLBACK_BASE_URI:weartrack://auth/callback}
+      handoff-ttl-seconds: ${APP_OAUTH_MOBILE_HANDOFF_TTL_SECONDS:180}
 
 # OAuth 클라이언트 설정은 실행 환경의 환경변수에서 주입합니다.
 oauth:
@@ -32,14 +37,17 @@ oauth:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: ${GOOGLE_REDIRECT_URI}
+    scope: ${GOOGLE_AUTH_SCOPE:openid email profile}
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
     client-secret: ${KAKAO_CLIENT_SECRET:}
     redirect-uri: ${KAKAO_REDIRECT_URI}
+    scope: ${KAKAO_AUTH_SCOPE:account_email}
   naver:
     client-id: ${NAVER_CLIENT_ID}
     client-secret: ${NAVER_CLIENT_SECRET}
     redirect-uri: ${NAVER_REDIRECT_URI}
+    scope: ${NAVER_AUTH_SCOPE:name email}
 
 file:
   upload-dir: uploads

--- a/src/test/java/com/weartrack/backend/domain/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/weartrack/backend/domain/member/controller/AuthControllerTest.java
@@ -76,6 +76,30 @@ class AuthControllerTest {
     }
 
     @Test
+    @DisplayName("서버가 발급한 웹 state면 쿠키 검증 없이 로그인 처리를 완료한다.")
+    void kakaoWebManagedStateCallbackSuccess() throws Exception {
+        SocialLoginResDto response = new SocialLoginResDto(
+                10L,
+                null,
+                false,
+                "access-token",
+                "refresh-token"
+        );
+
+        given(oAuthStateService.consumeIfPresent(AuthProvider.KAKAO, "managed-web-state"))
+                .willReturn(java.util.Optional.of(new OAuthStatePayload(AuthProvider.KAKAO, AuthClientType.WEB)));
+        given(authService.login(eq(AuthProvider.KAKAO), eq("kakao-code"), eq("managed-web-state")))
+                .willReturn(response);
+
+        mockMvc.perform(get("/login/oauth2/code/kakao")
+                        .param("state", "managed-web-state")
+                        .param("code", "kakao-code"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.memberId").value(10L));
+    }
+
+    @Test
     @DisplayName("소셜 로그인 요청이 유효하면 ApiResponse 형식으로 응답한다.")
     void socialLoginSuccess() throws Exception {
         SocialLoginReqDto request = new SocialLoginReqDto(AuthProvider.KAKAO, "auth-code", "oauth-state", null);

--- a/src/test/java/com/weartrack/backend/domain/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/weartrack/backend/domain/member/controller/AuthControllerTest.java
@@ -6,17 +6,26 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weartrack.backend.domain.member.constant.AuthClientType;
 import com.weartrack.backend.domain.member.constant.AuthProvider;
+import com.weartrack.backend.domain.member.dto.OAuthStatePayload;
 import com.weartrack.backend.domain.member.dto.request.SocialLoginReqDto;
 import com.weartrack.backend.domain.member.dto.response.SocialLoginResDto;
+import com.weartrack.backend.domain.member.exception.AuthErrorCode;
 import com.weartrack.backend.domain.member.service.AuthService;
+import com.weartrack.backend.domain.member.service.OAuthHandoffService;
+import com.weartrack.backend.domain.member.service.OAuthStateService;
+import com.weartrack.backend.domain.member.service.SocialOAuthAuthorizeService;
+import com.weartrack.backend.global.exception.GeneralException;
 import com.weartrack.backend.global.exception.GlobalExceptionHandler;
 import com.weartrack.backend.global.security.JwtAuthenticationFilter;
 import com.weartrack.backend.global.security.JwtTokenProvider;
 import jakarta.servlet.http.Cookie;
+import java.net.URI;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,15 +50,35 @@ class AuthControllerTest {
     private AuthService authService;
 
     @MockitoBean
+    private OAuthHandoffService oAuthHandoffService;
+
+    @MockitoBean
+    private OAuthStateService oAuthStateService;
+
+    @MockitoBean
+    private SocialOAuthAuthorizeService socialOAuthAuthorizeService;
+
+    @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
 
     @Test
+    @DisplayName("OAuth 시작 요청이면 provider authorize URL로 리다이렉트한다.")
+    void authorizeRedirectsToProvider() throws Exception {
+        given(socialOAuthAuthorizeService.buildAuthorizeUri(AuthProvider.KAKAO, AuthClientType.MOBILE))
+                .willReturn(URI.create("https://kauth.kakao.com/oauth/authorize?client_id=test"));
+
+        mockMvc.perform(get("/api/auth/social/authorize/kakao"))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("https://kauth.kakao.com/oauth/authorize?client_id=test"));
+    }
+
+    @Test
     @DisplayName("소셜 로그인 요청이 유효하면 ApiResponse 형식으로 응답한다.")
     void socialLoginSuccess() throws Exception {
-        SocialLoginReqDto request = new SocialLoginReqDto(AuthProvider.KAKAO, "auth-code", "oauth-state");
+        SocialLoginReqDto request = new SocialLoginReqDto(AuthProvider.KAKAO, "auth-code", "oauth-state", null);
         SocialLoginResDto response = new SocialLoginResDto(
                 1L,
                 null,
@@ -73,7 +102,8 @@ class AuthControllerTest {
     @Test
     @DisplayName("소셜 로그인 요청에서 authorizationCode가 비어 있으면 검증 오류를 반환한다.")
     void socialLoginValidationFail() throws Exception {
-        SocialLoginReqDto request = new SocialLoginReqDto(AuthProvider.KAKAO, "", "oauth-state");
+        SocialLoginReqDto request = new SocialLoginReqDto(AuthProvider.KAKAO, null, "oauth-state", null);
+        given(authService.login(request)).willThrow(new GeneralException(AuthErrorCode.INVALID_SOCIAL_LOGIN_REQUEST));
 
         mockMvc.perform(post("/api/auth/social/login")
                         .contentType(APPLICATION_JSON)
@@ -95,6 +125,8 @@ class AuthControllerTest {
 
         given(authService.login(eq(AuthProvider.KAKAO), eq("kakao-code"), eq("kakao-state"), eq("kakao-state")))
                 .willReturn(response);
+        given(oAuthStateService.consumeIfPresent(AuthProvider.KAKAO, "kakao-state"))
+                .willReturn(java.util.Optional.empty());
 
         mockMvc.perform(get("/login/oauth2/code/kakao")
                         .cookie(new Cookie("oauth-login-state", "kakao-state"))
@@ -103,6 +135,21 @@ class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andExpect(jsonPath("$.result.accessToken").value("access-token"));
+    }
+
+    @Test
+    @DisplayName("모바일 callback 요청이면 앱 딥링크로 handoff token을 리다이렉트한다.")
+    void kakaoMobileCallbackRedirectsToApp() throws Exception {
+        given(oAuthStateService.consumeIfPresent(AuthProvider.KAKAO, "mobile-oauth-state"))
+                .willReturn(java.util.Optional.of(new OAuthStatePayload(AuthProvider.KAKAO, AuthClientType.MOBILE)));
+        given(oAuthHandoffService.create(AuthProvider.KAKAO, "kakao-code", "mobile-oauth-state"))
+                .willReturn("handoff-token");
+
+        mockMvc.perform(get("/login/oauth2/code/kakao")
+                        .param("state", "mobile-oauth-state")
+                        .param("code", "kakao-code"))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("weartrack://auth/callback/kakao?handoff=handoff-token"));
     }
 
     @Test
@@ -118,6 +165,8 @@ class AuthControllerTest {
 
         given(authService.login(eq(AuthProvider.NAVER), eq("naver-code"), eq("naver-state"), eq("naver-state")))
                 .willReturn(response);
+        given(oAuthStateService.consumeIfPresent(AuthProvider.NAVER, "naver-state"))
+                .willReturn(java.util.Optional.empty());
 
         mockMvc.perform(get("/login/oauth2/code/naver")
                         .cookie(new Cookie("oauth-login-state", "naver-state"))

--- a/src/test/java/com/weartrack/backend/domain/member/service/AuthServiceTest.java
+++ b/src/test/java/com/weartrack/backend/domain/member/service/AuthServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.weartrack.backend.domain.member.constant.AuthProvider;
+import com.weartrack.backend.domain.member.dto.OAuthHandoffPayload;
 import com.weartrack.backend.domain.member.dto.SocialUserInfo;
 import com.weartrack.backend.domain.member.dto.request.SocialLoginReqDto;
 import com.weartrack.backend.domain.member.dto.response.SocialLoginResDto;
@@ -29,6 +30,9 @@ class AuthServiceTest {
     @Mock
     private AuthLoginTransactionService authLoginTransactionService;
 
+    @Mock
+    private OAuthHandoffService oAuthHandoffService;
+
     private AuthService authService;
 
     @BeforeEach
@@ -36,7 +40,8 @@ class AuthServiceTest {
         given(socialLoginProviderClient.supports()).willReturn(AuthProvider.KAKAO);
         authService = new AuthService(
                 List.of(socialLoginProviderClient),
-                authLoginTransactionService
+                authLoginTransactionService,
+                oAuthHandoffService
         );
     }
 
@@ -60,7 +65,7 @@ class AuthServiceTest {
         given(authLoginTransactionService.loginOrRegister(socialUserInfo)).willReturn(expectedResponse);
 
         SocialLoginResDto response = authService.login(
-                new SocialLoginReqDto(AuthProvider.KAKAO, "auth-code", "oauth-state")
+                new SocialLoginReqDto(AuthProvider.KAKAO, "auth-code", "oauth-state", null)
         );
 
         assertThat(response.memberId()).isEqualTo(1L);
@@ -90,7 +95,7 @@ class AuthServiceTest {
         given(authLoginTransactionService.loginOrRegister(socialUserInfo)).willReturn(expectedResponse);
 
         SocialLoginResDto response = authService.login(
-                new SocialLoginReqDto(AuthProvider.KAKAO, "new-auth-code", "oauth-state")
+                new SocialLoginReqDto(AuthProvider.KAKAO, "new-auth-code", "oauth-state", null)
         );
 
         assertThat(response.memberId()).isEqualTo(2L);
@@ -133,12 +138,42 @@ class AuthServiceTest {
     @Test
     @DisplayName("지원하지 않는 provider면 외부 호출 전에 예외를 던진다.")
     void loginFailsWhenProviderUnsupported() {
-        SocialLoginReqDto request = new SocialLoginReqDto(AuthProvider.GOOGLE, "auth-code", "oauth-state");
+        SocialLoginReqDto request = new SocialLoginReqDto(AuthProvider.GOOGLE, "auth-code", "oauth-state", null);
 
         assertThatThrownBy(() -> authService.login(request))
                 .isInstanceOf(GeneralException.class);
 
         verify(socialLoginProviderClient, never()).getUserInfo(any(), any());
         verify(authLoginTransactionService, never()).loginOrRegister(any());
+    }
+
+    @Test
+    @DisplayName("handoff token 로그인 요청이면 저장된 code/state로 provider 조회를 진행한다.")
+    void loginWithHandoffToken() {
+        SocialUserInfo socialUserInfo = new SocialUserInfo(
+                AuthProvider.KAKAO,
+                "provider-user-id",
+                "weartrack@example.com"
+        );
+        SocialLoginResDto expectedResponse = new SocialLoginResDto(
+                4L,
+                null,
+                false,
+                "access-token",
+                "refresh-token"
+        );
+
+        given(oAuthHandoffService.consume(AuthProvider.KAKAO, "handoff-token"))
+                .willReturn(new OAuthHandoffPayload(AuthProvider.KAKAO, "auth-code", "server-state"));
+        given(socialLoginProviderClient.getUserInfo("auth-code", "server-state")).willReturn(socialUserInfo);
+        given(authLoginTransactionService.loginOrRegister(socialUserInfo)).willReturn(expectedResponse);
+
+        SocialLoginResDto response = authService.login(
+                new SocialLoginReqDto(AuthProvider.KAKAO, null, null, "handoff-token")
+        );
+
+        assertThat(response.memberId()).isEqualTo(4L);
+        verify(oAuthHandoffService).consume(AuthProvider.KAKAO, "handoff-token");
+        verify(authLoginTransactionService).loginOrRegister(socialUserInfo);
     }
 }


### PR DESCRIPTION
- OAuth 시작 API 추가
- state 저장 및 검증 로직 추가
- handoff token 기반 앱 복귀 처리 추가
- 구글, 카카오, 네이버 모바일 로그인 흐름 통합

### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용

- 모바일 소셜 로그인용 OAuth 시작 API `GET /api/auth/social/authorize/{provider}` 추가
- OAuth 시작 시 provider별 authorize URL 생성 및 서버측 `state` 발급/저장 로직 추가
- OAuth callback에서 서버가 저장한 `state` 검증 후 모바일 요청일 경우 1회용 `handoff token` 생성하도록 변경
- 앱 딥링크 `weartrack://auth/callback/{provider}?handoff=...` 로 복귀하는 브릿지 흐름 추가
- `POST /api/auth/social/login` 에서 `handoffToken` 기반 로그인 처리 지원 추가
- 구글, 카카오, 네이버 모바일 로그인 흐름을 공통 브릿지 구조로 통합
- 모바일 OAuth 관련 설정값 및 테스트 코드 추가

### 🌀 PR Point

- 모바일 로그인 시작은 앱에서 provider URL을 직접 만들지 않고 `/api/auth/social/authorize/{provider}?client=MOBILE` 를 호출하는 방식으로 변경됩니다.
- 모바일 callback은 `code` 대신 `handoff` 를 앱에 전달합니다.
- `handoff token` 과 `state` 는 모두 메모리 저장소 기반이며 TTL, 1회 사용으로 처리했습니다.
- 운영 환경이 멀티 인스턴스라면 추후 Redis 같은 외부 저장소로 옮기는 것이 필요할 수 있습니다.
- provider 콘솔 redirect URI 는 기존처럼 백엔드 callback URL을 유지해야 합니다.


### 🍰 참고사항

환경변수 추가 하였습니다 노션에 올려두었습니다

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 모바일 앱용 OAuth 소셜 인증 엔드포인트 추가
  * 토큰 기반 모바일 인증 흐름 지원

* **개선 사항**
  * 소셜 로그인 요청 처리 강화
  * 모바일 및 웹 클라이언트 구분 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->