### PR TITLE
Fix: 빈 생성 오류 및 S3 region 설정 수정

### DIFF
--- a/src/main/java/com/weartrack/backend/domain/clothes/service/S3StorageService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/S3StorageService.java
@@ -23,7 +23,7 @@ public class S3StorageService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    @Value("${cloud.aws.region.static}")
+    @Value("${cloud.aws.region}")
     private String region;
 
     public SavedImage uploadClothesImage(MultipartFile image) {

--- a/src/main/java/com/weartrack/backend/domain/member/service/OAuthHandoffService.java
+++ b/src/main/java/com/weartrack/backend/domain/member/service/OAuthHandoffService.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +21,7 @@ public class OAuthHandoffService {
     private final Duration ttl;
     private final Clock clock;
 
+    @Autowired
     public OAuthHandoffService(
             @Value("${app.oauth.mobile.handoff-ttl-seconds:180}") long handoffTtlSeconds
     ) {

--- a/src/main/java/com/weartrack/backend/domain/member/service/OAuthStateService.java
+++ b/src/main/java/com/weartrack/backend/domain/member/service/OAuthStateService.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +23,7 @@ public class OAuthStateService {
     private final Duration ttl;
     private final Clock clock;
 
+    @Autowired
     public OAuthStateService(
             @Value("${app.oauth.state-ttl-seconds:300}") long stateTtlSeconds
     ) {

--- a/src/main/java/com/weartrack/backend/global/config/S3Config.java
+++ b/src/main/java/com/weartrack/backend/global/config/S3Config.java
@@ -11,7 +11,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Configuration
 public class S3Config {
 
-    @Value("${cloud.aws.region.static}")
+    @Value("${cloud.aws.region}")
     private String region;
 
     @Value("${cloud.aws.credentials.access-key}")


### PR DESCRIPTION
- OAuth 서비스 생성자 주입 오류 수정
- S3 region 설정에서 .static 제거

### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용

- `OAuthHandoffService`, `OAuthStateService` 의 스프링 빈 생성자에 주입 대상 생성자를 명시해 빈 생성 오류를 수정했습니다.
- `S3Config`, `S3StorageService` 에서 AWS region 설정 키를 `cloud.aws.region.static` 에서 `cloud.aws.region` 으로 변경했습니다.


### 🌀 PR Point

- 로그인 관련 빈 생성 오류는 OAuth 서비스 클래스에 생성자가 2개 있는 상태에서 스프링이 주입 생성자를 명확히 선택하지 못해 발생했습니다.
- S3 region 설정은 현재 `application-prod.yml` 구조에 맞춰 참조 키를 정리한 수정입니다.


### 🍰 참고사항

- 로그인 관련 테스트는 다시 실행해서 통과 확인했습니다.
- S3 설정 변경은 운영에 이미 반영된 값과 main 브랜치 코드를 맞추기 위한 수정입니다.


### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * AWS 리전 설정 구성 프로퍼티 업데이트
  * Spring 의존성 주입 어노테이션 명시화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->