### PR TITLE
fix: update home summary and allow optional closet image upload

### DIFF
--- a/src/main/java/com/weartrack/backend/domain/closet/controller/ClosetPhotoController.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/controller/ClosetPhotoController.java
@@ -31,7 +31,7 @@ public class ClosetPhotoController {
     public ApiResponse<ClosetPhotoCreateResDto> uploadClosetPhoto(
             @AuthenticationPrincipal JwtPrincipal principal,
             @RequestParam("templateId") @NotNull Integer templateId,
-            @RequestPart("image") MultipartFile image
+            @RequestPart(value = "image", required = false) MultipartFile image
     ) {
 
         ClosetPhotoCreateResDto response = closetPhotoService.uploadClosetPhoto(

--- a/src/main/java/com/weartrack/backend/domain/closet/dto/request/ClosetCreateReqDto.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/dto/request/ClosetCreateReqDto.java
@@ -11,7 +11,6 @@ public record ClosetCreateReqDto(
         @NotNull(message = "templateId는 필수입니다.")
         Integer templateId,
 
-        @NotBlank(message = "imageUrl은 필수입니다.")
         String imageUrl,
 
         @NotEmpty(message = "칸 정보는 필수입니다.")

--- a/src/main/java/com/weartrack/backend/domain/closet/entity/Closet.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/entity/Closet.java
@@ -25,7 +25,7 @@ public class Closet extends BaseTimeEntity {
     @Column(name = "template_id", nullable = false)
     private Integer templateId;
 
-    @Column(name = "image_url", nullable = false)
+    @Column(name = "image_url")
     private String imageUrl;
 
     @Builder.Default

--- a/src/main/java/com/weartrack/backend/domain/closet/repository/ClosetRepository.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/repository/ClosetRepository.java
@@ -4,4 +4,6 @@ import com.weartrack.backend.domain.closet.entity.Closet;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClosetRepository extends JpaRepository<Closet, Long> {
+
+    long countByMemberId(Long memberId);
 }

--- a/src/main/java/com/weartrack/backend/domain/closet/repository/ClosetSectionRepository.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/repository/ClosetSectionRepository.java
@@ -2,6 +2,15 @@ package com.weartrack.backend.domain.closet.repository;
 
 import com.weartrack.backend.domain.closet.entity.ClosetSection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ClosetSectionRepository extends JpaRepository<ClosetSection, Long> {
+
+    @Query("""
+        SELECT COUNT(cs)
+        FROM ClosetSection cs
+        WHERE cs.closet.memberId = :memberId
+        """)
+    long countByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/weartrack/backend/domain/closet/service/ClosetPhotoService.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/service/ClosetPhotoService.java
@@ -1,7 +1,7 @@
 package com.weartrack.backend.domain.closet.service;
 
-import com.weartrack.backend.domain.closet.dto.response.ClosetPhotoCreateResDto;
 import com.weartrack.backend.domain.closet.dto.PredictedSectionDto;
+import com.weartrack.backend.domain.closet.dto.response.ClosetPhotoCreateResDto;
 import com.weartrack.backend.domain.closet.entity.ClosetTemplate;
 import com.weartrack.backend.domain.clothes.service.S3StorageService;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,12 @@ public class ClosetPhotoService {
     public ClosetPhotoCreateResDto uploadClosetPhoto(Long memberId, Integer templateId, MultipartFile image) {
         ClosetTemplate template = ClosetTemplate.from(templateId);
 
-        S3StorageService.SavedImage savedImage = s3StorageService.uploadClosetImage(image);
+        String imageUrl = null;
+
+        if (image != null && !image.isEmpty()) {
+            S3StorageService.SavedImage savedImage = s3StorageService.uploadClosetImage(image);
+            imageUrl = savedImage.getImageUrl();
+        }
 
         List<PredictedSectionDto> predictedSections = template.getSectionOrders()
                 .stream()
@@ -29,7 +34,7 @@ public class ClosetPhotoService {
         return new ClosetPhotoCreateResDto(
                 "SUCCESS",
                 template.getTemplateId(),
-                savedImage.getImageUrl(),
+                imageUrl,
                 template.getSectionCount(),
                 predictedSections
         );

--- a/src/main/java/com/weartrack/backend/domain/home/dto/HomeSummaryResDto.java
+++ b/src/main/java/com/weartrack/backend/domain/home/dto/HomeSummaryResDto.java
@@ -3,6 +3,8 @@ package com.weartrack.backend.domain.home.dto;
 public record HomeSummaryResDto(
         long totalClothesCount,
         long weeklyExpenseAmount,
-        int weeklyClosetUsageRate
+        int weeklyClosetUsageRate,
+        long closetCount,
+        long storageCount
 ) {
 }

--- a/src/main/java/com/weartrack/backend/domain/home/service/HomeService.java
+++ b/src/main/java/com/weartrack/backend/domain/home/service/HomeService.java
@@ -1,5 +1,7 @@
 package com.weartrack.backend.domain.home.service;
 
+import com.weartrack.backend.domain.closet.repository.ClosetRepository;
+import com.weartrack.backend.domain.closet.repository.ClosetSectionRepository;
 import com.weartrack.backend.domain.clothes.repository.ClothesRepository;
 import com.weartrack.backend.domain.home.dto.HomeSummaryResDto;
 import java.time.LocalDateTime;
@@ -12,9 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class HomeService {
 
-    private static final int HARDCODED_WEEKLY_CLOSET_USAGE_RATE = 73;
+    private static final int TEMP_WEEKLY_CLOSET_USAGE_RATE = 73;
 
     private final ClothesRepository clothesRepository;
+    private final ClosetRepository closetRepository;
+    private final ClosetSectionRepository closetSectionRepository;
 
     public HomeSummaryResDto getHomeSummary(Long memberId) {
         LocalDateTime oneWeekAgo = LocalDateTime.now().minusDays(7);
@@ -22,10 +26,33 @@ public class HomeService {
         long totalClothesCount = clothesRepository.countByMemberId(memberId);
         long weeklyExpenseAmount = clothesRepository.sumWeeklyExpenseAmount(memberId, oneWeekAgo);
 
+        long closetCount = closetRepository.countByMemberId(memberId);
+        long storageCount = closetSectionRepository.countByMemberId(memberId);
+
+        int weeklyClosetUsageRate = calculateWeeklyClosetUsageRate(
+                totalClothesCount,
+                closetCount,
+                storageCount
+        );
+
         return new HomeSummaryResDto(
                 totalClothesCount,
                 weeklyExpenseAmount,
-                HARDCODED_WEEKLY_CLOSET_USAGE_RATE
+                weeklyClosetUsageRate,
+                closetCount,
+                storageCount
         );
+    }
+
+    private int calculateWeeklyClosetUsageRate(
+            long totalClothesCount,
+            long closetCount,
+            long storageCount
+    ) {
+        if (totalClothesCount == 0 || closetCount == 0 || storageCount == 0) {
+            return 0;
+        }
+
+        return TEMP_WEEKLY_CLOSET_USAGE_RATE;
     }
 }


### PR DESCRIPTION
## 작업 내용

### 1. 메인 홈 API 응답 개선

* `/api/home` 응답에 아래 값 추가

  * `closetCount`
  * `storageCount`
* 사용자의 등록 옷장 개수 및 전체 섹션 수를 함께 반환하도록 수정

### 2. weeklyClosetUsageRate 예외 처리

* 기존에는 모든 계정에 임시값 `73`이 고정 반환되던 문제 수정
* 등록된 옷/옷장 데이터가 없는 경우 `0` 반환하도록 변경

### 3. 옷장 사진 업로드 optional 처리

* MVP 기준으로 템플릿 선택만으로 옷장 생성 가능하도록 수정
* `/api/closets/photo`

  * `image` multipart 필수값 제거
* `/api/closets`

  * `imageUrl` null 허용
* 이미지 없이도 기본 섹션 목록 반환 및 최종 옷장 등록 가능하도록 변경

## 테스트

* `/api/home` 응답값 증가 확인
* 데이터 없는 계정에서 `weeklyClosetUsageRate = 0` 확인
* 이미지 없이 `/api/closets/photo` 정상 동작 확인
* 이미지 없이 `/api/closets` 최종 등록 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **개선 사항**
  * 클로짓 생성 시 사진 업로드를 선택사항으로 변경하여 더 유연한 등록 가능
  * 홈 대시보드에 클로짓 및 저장소 개수 정보 추가 표시
  * 클로짓 정보 저장 시 이미지 필드 필수값 요구사항 제거

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WEARTRACK/BE/pull/28)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->