### PR TITLE
fix: AI 분석 실패 시 옷 수기 등록 가능하도록 수정

### DIFF
--- a/src/main/java/com/weartrack/backend/domain/closet/entity/Closet.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/entity/Closet.java
@@ -19,7 +19,7 @@ public class Closet extends BaseTimeEntity {
     @Column(name = "closet_id")
     private Long closetId;
 
-    @Column(name = "member_id", nullable = false)
+    @Column(name = "member_id", nullable = false, unique = true)
     private Long memberId;
 
     @Column(name = "template_id", nullable = false)

--- a/src/main/java/com/weartrack/backend/domain/closet/exception/ClosetErrorCode.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/exception/ClosetErrorCode.java
@@ -21,6 +21,7 @@ public enum ClosetErrorCode implements BaseErrorCode {
     SECTION_NOT_IN_CLOSET("CLOSET_4010", "해당 옷장에 속하지 않는 섹션입니다.", HttpStatus.BAD_REQUEST),
     SECTION_COUNT_MISMATCH("CLOSET_4011", "템플릿의 칸 개수가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     SECTION_NOT_OWNED("CLOSET_4012", "본인의 섹션이 아닙니다.", HttpStatus.FORBIDDEN),
+    DUPLICATE_CLOSET("CLOSET_4013", "이미 등록된 옷장이 있습니다.", HttpStatus.CONFLICT),
     CLOSET_IMAGE_SAVE_FAILED("CLOSET_5001", "옷장 이미지 저장 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;

--- a/src/main/java/com/weartrack/backend/domain/closet/repository/ClosetRepository.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/repository/ClosetRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ClosetRepository extends JpaRepository<Closet, Long> {
 
     long countByMemberId(Long memberId);
+
+    boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/com/weartrack/backend/domain/closet/service/ClosetService.java
+++ b/src/main/java/com/weartrack/backend/domain/closet/service/ClosetService.java
@@ -38,6 +38,11 @@ public class ClosetService {
     private final ClosetStatisticsMapper closetStatisticsMapper;
 
     public ClosetCreateResDto createCloset(Long memberId, ClosetCreateReqDto request) {
+
+        if (closetRepository.existsByMemberId(memberId)) {
+            throw new GeneralException(ClosetErrorCode.DUPLICATE_CLOSET);
+        }
+
         ClosetTemplate template = ClosetTemplate.from(request.templateId());
 
         validateSections(template, request.sections());

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesPhotoService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesPhotoService.java
@@ -1,8 +1,8 @@
 package com.weartrack.backend.domain.clothes.service;
 
+import com.weartrack.backend.domain.clothes.dto.ResultDto;
 import com.weartrack.backend.domain.clothes.dto.response.AiClothesPredictionResponse;
 import com.weartrack.backend.domain.clothes.dto.response.ClothesPhotoCreateResponse;
-import com.weartrack.backend.domain.clothes.dto.ResultDto;
 import com.weartrack.backend.domain.clothes.entity.AnalysisStatus;
 import com.weartrack.backend.domain.clothes.entity.ClothesPhoto;
 import com.weartrack.backend.domain.clothes.repository.ClothesPhotoRepository;
@@ -59,12 +59,23 @@ public class ClothesPhotoService {
             );
 
         } catch (Exception e) {
-            try {
-                s3StorageService.delete(savedImage.getKey());
-            } catch (Exception cleanupException) {
-                e.addSuppressed(cleanupException);
-            }
-            throw e;
+            ClothesPhoto failedPhoto = ClothesPhoto.builder()
+                    .memberId(memberId)
+                    .imageUrl(savedImage.getImageUrl())
+                    .analysisStatus(AnalysisStatus.FAIL)
+                    .predictedCategory(null)
+                    .predictedColor(null)
+                    .build();
+
+            ClothesPhoto savedPhoto = clothesPhotoRepository.save(failedPhoto);
+
+            return new ClothesPhotoCreateResponse(
+                    savedPhoto.getId(),
+                    savedPhoto.getImageUrl(),
+                    savedPhoto.getAnalysisStatus(),
+                    savedPhoto.getPredictedCategory(),
+                    savedPhoto.getPredictedColor()
+            );
         }
     }
 }


### PR DESCRIPTION
## 작업 내용

AI 분석 실패 시에도 사용자가 수기 입력으로 옷 등록을 이어갈 수 있도록 수정했습니다.

기존에는:
- S3 이미지 업로드 성공
- AI 분석 실패
- 업로드된 이미지 삭제
- 예외 throw

구조였기 때문에 프론트에서 photoId/imageUrl을 받지 못해 수기 등록이 불가능했습니다.

수정 후에는:
- 이미지 업로드 성공 시 S3 이미지를 유지
- clothes_photo 테이블에 FAIL 상태 저장
- photoId/imageUrl 반환
- 프론트에서 수기 입력 후 POST /api/clothes 가능

하도록 변경했습니다.

---

## 변경 사항

### ClothesPhotoService
- AI 분석 실패 시 S3 이미지 삭제 로직 제거
- FAIL 상태의 ClothesPhoto 저장
- 실패 시에도 photoId/imageUrl 응답 반환

### AnalysisStatus
- FAIL 상태 사용하도록 수정

---

## 테스트

### 성공 케이스
- AI 분석 성공 시 SUCCESS 상태 반환 확인

### 실패 케이스
- AI 서버 연결 실패 시:
  - photoId 반환
  - imageUrl 반환
  - analysisStatus=FAIL 반환
  - predictedCategory/predictedColor null 반환 확인

### 수기 등록
- FAIL 상태 photoId로 POST /api/clothes 정상 등록 확인
---
### [FIX] 옷장 중복 등록 방지 로직 추가

## 변경 사항

### ClosetRepository
- existsByMemberId() 추가

### ClosetService
- createCloset() 진입 시 중복 옷장 검사 추가

### ClosetErrorCode
- DUPLICATE_CLOSET 에러 코드 추가

---

## 테스트

### 첫 번째 등록
- POST /api/closets 성공 확인

### 두 번째 등록
- 동일 계정으로 재호출 시:
  - CLOSET_4013 반환 확인
  - "이미 등록된 옷장이 있습니다." 메시지 확인



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 옷장 중복 생성 방지: 사용자가 이미 등록한 옷장이 있을 경우 추가 생성을 차단합니다.

* **Bug Fixes**
  * 의류 사진 분석 실패 시 처리 개선: 실패 상태를 기록하고 명확한 상태 정보를 반환합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WEARTRACK/BE/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->