### PR TITLE
[REFACTOR] 옷 사진 AI 분석 비동기 처리 구조 개선

### DIFF
--- a/src/main/java/com/weartrack/backend/WeartrackBackendApplication.java
+++ b/src/main/java/com/weartrack/backend/WeartrackBackendApplication.java
@@ -3,10 +3,12 @@ package com.weartrack.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 /**
  * WearTrack 백엔드 애플리케이션 시작점이다.
  */
+@EnableAsync
 @EnableRetry
 @SpringBootApplication
 public class WeartrackBackendApplication {

--- a/src/main/java/com/weartrack/backend/domain/clothes/controller/ClothesPhotoController.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/controller/ClothesPhotoController.java
@@ -22,8 +22,13 @@ public class ClothesPhotoController {
     private final ClothesPhotoService clothesPhotoService;
 
     @Operation(
-            summary = "옷 사진 등록 및 AI 분석",
-            description = "옷 사진을 업로드하면 로컬에 저장하고 AI 서버를 호출하여 카테고리와 색상을 예측합니다."
+            summary = "옷 사진 등록 및 AI 분석 요청",
+            description = """
+                    옷 사진을 업로드한 뒤 imageUrl과 photoId를 즉시 반환합니다.
+                    AI 분석은 백그라운드에서 비동기로 처리되며,
+                    최초 응답의 analysisStatus는 PENDING입니다.
+                    분석 결과는 GET /api/clothes/photo/{photoId}/analysis API로 조회합니다.
+                    """
     )
     @PostMapping(
             value = "/photo",
@@ -33,10 +38,32 @@ public class ClothesPhotoController {
             @AuthenticationPrincipal JwtPrincipal principal,
             @Valid @RequestPart("image") MultipartFile image
     ) {
-        Long userId = principal.memberId();
+        Long memberId = principal.memberId();
 
         ClothesPhotoCreateResponse response =
-                clothesPhotoService.uploadAndAnalyze(userId, image);
+                clothesPhotoService.uploadAndAnalyze(memberId, image);
+
+        return ApiResponse.success(response);
+    }
+
+    @Operation(
+            summary = "옷 사진 AI 분석 상태 조회",
+            description = """
+                    업로드한 옷 사진의 AI 분석 상태를 조회합니다.
+                    PENDING이면 아직 분석 중이고,
+                    SUCCESS이면 predictedCategory와 predictedColor가 포함됩니다.
+                    FAIL이면 분석에 실패한 상태입니다.
+                    """
+    )
+    @GetMapping("/photo/{photoId}/analysis")
+    public ApiResponse<ClothesPhotoCreateResponse> getClothesPhotoAnalysis(
+            @AuthenticationPrincipal JwtPrincipal principal,
+            @PathVariable Long photoId
+    ) {
+        Long memberId = principal.memberId();
+
+        ClothesPhotoCreateResponse response =
+                clothesPhotoService.getAnalysisResult(memberId, photoId);
 
         return ApiResponse.success(response);
     }

--- a/src/main/java/com/weartrack/backend/domain/clothes/entity/ClothesPhoto.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/entity/ClothesPhoto.java
@@ -1,6 +1,5 @@
 package com.weartrack.backend.domain.clothes.entity;
 
-import com.weartrack.backend.domain.clothes.entity.AnalysisStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -40,6 +39,18 @@ public class ClothesPhoto {
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    public void markAnalysisSuccess(String predictedCategory, String predictedColor) {
+        this.analysisStatus = AnalysisStatus.SUCCESS;
+        this.predictedCategory = predictedCategory;
+        this.predictedColor = predictedColor;
+    }
+
+    public void markAnalysisFail() {
+        this.analysisStatus = AnalysisStatus.FAIL;
+        this.predictedCategory = null;
+        this.predictedColor = null;
+    }
 
     @PrePersist
     public void prePersist() {

--- a/src/main/java/com/weartrack/backend/domain/clothes/exception/ClothesErrorCode.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/exception/ClothesErrorCode.java
@@ -10,8 +10,10 @@ import org.springframework.http.HttpStatus;
 public enum ClothesErrorCode implements BaseErrorCode {
 
     CLOTHES_NOT_FOUND("CLOTHES_4001", "해당 옷의 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    CLOTHES_NOT_OWNED("CLOTHES_4002", "본인의 옷이 아닙니다.", HttpStatus.FORBIDDEN)
-    ;
+    CLOTHES_NOT_OWNED("CLOTHES_4002", "본인의 옷이 아닙니다.", HttpStatus.FORBIDDEN),
+
+    CLOTHES_PHOTO_NOT_FOUND("CLOTHES_PHOTO_4001", "해당 옷 사진 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    CLOTHES_PHOTO_NOT_OWNED("CLOTHES_PHOTO_4002", "본인의 옷 사진이 아닙니다.", HttpStatus.FORBIDDEN);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/weartrack/backend/domain/clothes/exception/ClothesErrorCode.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/exception/ClothesErrorCode.java
@@ -9,11 +9,35 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ClothesErrorCode implements BaseErrorCode {
 
-    CLOTHES_NOT_FOUND("CLOTHES_4001", "해당 옷의 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    CLOTHES_NOT_OWNED("CLOTHES_4002", "본인의 옷이 아닙니다.", HttpStatus.FORBIDDEN),
+    CLOTHES_NOT_FOUND(
+            "CLOTHES_4001",
+            "해당 옷의 정보를 찾을 수 없습니다.",
+            HttpStatus.NOT_FOUND
+    ),
 
-    CLOTHES_PHOTO_NOT_FOUND("CLOTHES_PHOTO_4001", "해당 옷 사진 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    CLOTHES_PHOTO_NOT_OWNED("CLOTHES_PHOTO_4002", "본인의 옷 사진이 아닙니다.", HttpStatus.FORBIDDEN);
+    CLOTHES_NOT_OWNED(
+            "CLOTHES_4002",
+            "본인의 옷이 아닙니다.",
+            HttpStatus.FORBIDDEN
+    ),
+
+    CLOTHES_PHOTO_NOT_FOUND(
+            "CLOTHES_PHOTO_4001",
+            "해당 옷 사진 정보를 찾을 수 없습니다.",
+            HttpStatus.NOT_FOUND
+    ),
+
+    CLOTHES_PHOTO_NOT_OWNED(
+            "CLOTHES_PHOTO_4002",
+            "본인의 옷 사진이 아닙니다.",
+            HttpStatus.FORBIDDEN
+    ),
+
+    CLOTHES_IMAGE_READ_FAILED(
+            "CLOTHES_PHOTO_4003",
+            "이미지 파일을 읽는 중 오류가 발생했습니다.",
+            HttpStatus.BAD_REQUEST
+    );
 
     private final String code;
     private final String message;

--- a/src/main/java/com/weartrack/backend/domain/clothes/repository/ClothesPhotoRepository.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/repository/ClothesPhotoRepository.java
@@ -3,5 +3,9 @@ package com.weartrack.backend.domain.clothes.repository;
 import com.weartrack.backend.domain.clothes.entity.ClothesPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ClothesPhotoRepository extends JpaRepository<ClothesPhoto, Long> {
+
+    Optional<ClothesPhoto> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesAiClient.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesAiClient.java
@@ -4,16 +4,12 @@ import com.weartrack.backend.domain.clothes.dto.response.AiClothesPredictionResp
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.io.File;
-import java.io.IOException;
 import java.time.Duration;
 
 @Component
@@ -25,31 +21,29 @@ public class ClothesAiClient {
     @Value("${ai.base-url}")
     private String aiBaseUrl;
 
-    public AiClothesPredictionResponse predict(MultipartFile image) {
-        try {
-            ByteArrayResource imageResource = new ByteArrayResource(image.getBytes()) {
-                @Override
-                public String getFilename() {
-                    return image.getOriginalFilename();
+    public AiClothesPredictionResponse predict(byte[] imageBytes, String originalFilename, String contentType) {
+        ByteArrayResource imageResource = new ByteArrayResource(imageBytes) {
+            @Override
+            public String getFilename() {
+                if (originalFilename == null || originalFilename.isBlank()) {
+                    return "clothes-image.jpg";
                 }
-            };
+                return originalFilename;
+            }
+        };
 
-            LinkedMultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-            body.add("file", imageResource);
+        LinkedMultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("file", imageResource);
 
-            return webClientBuilder
-                    .baseUrl(aiBaseUrl)
-                    .build()
-                    .post()
-                    .uri("/predict-clothes")
-                    .contentType(MediaType.MULTIPART_FORM_DATA)
-                    .body(BodyInserters.fromMultipartData(body))
-                    .retrieve()
-                    .bodyToMono(AiClothesPredictionResponse.class)
-                    .block(Duration.ofSeconds(180));
-
-        } catch (IOException e) {
-            throw new IllegalArgumentException("AI 서버로 전달할 이미지 파일을 읽는 중 오류가 발생했습니다.");
-        }
+        return webClientBuilder
+                .baseUrl(aiBaseUrl)
+                .build()
+                .post()
+                .uri("/predict-clothes")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(body))
+                .retrieve()
+                .bodyToMono(AiClothesPredictionResponse.class)
+                .block(Duration.ofSeconds(60));
     }
 }

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesAiClient.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesAiClient.java
@@ -5,8 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Component;
-import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -32,8 +32,13 @@ public class ClothesAiClient {
             }
         };
 
-        LinkedMultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-        body.add("file", imageResource);
+        MediaType imageMediaType = resolveMediaType(contentType);
+
+        MultipartBodyBuilder bodyBuilder = new MultipartBodyBuilder();
+        bodyBuilder
+                .part("file", imageResource)
+                .filename(imageResource.getFilename())
+                .contentType(imageMediaType);
 
         return webClientBuilder
                 .baseUrl(aiBaseUrl)
@@ -41,9 +46,21 @@ public class ClothesAiClient {
                 .post()
                 .uri("/predict-clothes")
                 .contentType(MediaType.MULTIPART_FORM_DATA)
-                .body(BodyInserters.fromMultipartData(body))
+                .body(BodyInserters.fromMultipartData(bodyBuilder.build()))
                 .retrieve()
                 .bodyToMono(AiClothesPredictionResponse.class)
                 .block(Duration.ofSeconds(60));
+    }
+
+    private MediaType resolveMediaType(String contentType) {
+        if (contentType == null || contentType.isBlank()) {
+            return MediaType.APPLICATION_OCTET_STREAM;
+        }
+
+        try {
+            return MediaType.parseMediaType(contentType);
+        } catch (IllegalArgumentException e) {
+            return MediaType.APPLICATION_OCTET_STREAM;
+        }
     }
 }

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesPhotoAnalysisAsyncService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesPhotoAnalysisAsyncService.java
@@ -1,0 +1,61 @@
+package com.weartrack.backend.domain.clothes.service;
+
+import com.weartrack.backend.domain.clothes.dto.ResultDto;
+import com.weartrack.backend.domain.clothes.dto.response.AiClothesPredictionResponse;
+import com.weartrack.backend.domain.clothes.entity.ClothesPhoto;
+import com.weartrack.backend.domain.clothes.repository.ClothesPhotoRepository;
+import com.weartrack.backend.domain.clothes.util.ColorMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ClothesPhotoAnalysisAsyncService {
+
+    private final ClothesAiClient clothesAiClient;
+    private final ClothesPhotoRepository clothesPhotoRepository;
+
+    @Async("aiAnalysisExecutor")
+    @Transactional
+    public void analyzeAsync(
+            Long photoId,
+            byte[] imageBytes,
+            String originalFilename,
+            String contentType
+    ) {
+        try {
+            AiClothesPredictionResponse aiResult =
+                    clothesAiClient.predict(imageBytes, originalFilename, contentType);
+
+            if (aiResult == null || aiResult.results() == null || aiResult.results().isEmpty()) {
+                throw new IllegalStateException("AI 분석 결과가 없습니다.");
+            }
+
+            List<ResultDto> results = aiResult.results();
+            ResultDto firstResult = results.get(0);
+
+            String predictedCategory = firstResult.category();
+            String predictedColor = ColorMapper.toEnglish(firstResult.color());
+
+            ClothesPhoto clothesPhoto = clothesPhotoRepository.findById(photoId)
+                    .orElseThrow(() -> new IllegalArgumentException("옷 사진 정보를 찾을 수 없습니다. photoId=" + photoId));
+
+            clothesPhoto.markAnalysisSuccess(predictedCategory, predictedColor);
+
+            log.info("옷 사진 AI 분석 성공: photoId={}, category={}, color={}",
+                    photoId, predictedCategory, predictedColor);
+
+        } catch (Exception e) {
+            log.warn("옷 사진 AI 분석 실패: photoId={}, reason={}", photoId, e.getMessage(), e);
+
+            clothesPhotoRepository.findById(photoId)
+                    .ifPresent(ClothesPhoto::markAnalysisFail);
+        }
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesPhotoService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesPhotoService.java
@@ -27,24 +27,30 @@ public class ClothesPhotoService {
 
         S3StorageService.SavedImage savedImage = s3StorageService.uploadClothesImage(image);
 
-        ClothesPhoto clothesPhoto = ClothesPhoto.builder()
-                .memberId(memberId)
-                .imageUrl(savedImage.getImageUrl())
-                .analysisStatus(AnalysisStatus.PENDING)
-                .predictedCategory(null)
-                .predictedColor(null)
-                .build();
+        try {
+            ClothesPhoto clothesPhoto = ClothesPhoto.builder()
+                    .memberId(memberId)
+                    .imageUrl(savedImage.getImageUrl())
+                    .analysisStatus(AnalysisStatus.PENDING)
+                    .predictedCategory(null)
+                    .predictedColor(null)
+                    .build();
 
-        ClothesPhoto savedPhoto = clothesPhotoRepository.save(clothesPhoto);
+            ClothesPhoto savedPhoto = clothesPhotoRepository.save(clothesPhoto);
 
-        clothesPhotoAnalysisAsyncService.analyzeAsync(
-                savedPhoto.getId(),
-                imageBytes,
-                originalFilename,
-                contentType
-        );
+            clothesPhotoAnalysisAsyncService.analyzeAsync(
+                    savedPhoto.getId(),
+                    imageBytes,
+                    originalFilename,
+                    contentType
+            );
 
-        return toResponse(savedPhoto);
+            return toResponse(savedPhoto);
+
+        } catch (Exception e) {
+            s3StorageService.deleteByKey(savedImage.getKey());
+            throw e;
+        }
     }
 
     public ClothesPhotoCreateResponse getAnalysisResult(Long memberId, Long photoId) {
@@ -68,7 +74,7 @@ public class ClothesPhotoService {
         try {
             return image.getBytes();
         } catch (IOException e) {
-            throw new IllegalArgumentException("이미지 파일을 읽는 중 오류가 발생했습니다.");
+            throw new IllegalArgumentException("이미지 파일을 읽는 중 오류가 발생했습니다.", e);
         }
     }
 }

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesPhotoService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesPhotoService.java
@@ -1,81 +1,74 @@
 package com.weartrack.backend.domain.clothes.service;
 
-import com.weartrack.backend.domain.clothes.dto.ResultDto;
-import com.weartrack.backend.domain.clothes.dto.response.AiClothesPredictionResponse;
 import com.weartrack.backend.domain.clothes.dto.response.ClothesPhotoCreateResponse;
 import com.weartrack.backend.domain.clothes.entity.AnalysisStatus;
 import com.weartrack.backend.domain.clothes.entity.ClothesPhoto;
+import com.weartrack.backend.domain.clothes.exception.ClothesErrorCode;
 import com.weartrack.backend.domain.clothes.repository.ClothesPhotoRepository;
-import com.weartrack.backend.domain.clothes.util.ColorMapper;
+import com.weartrack.backend.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
+import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class ClothesPhotoService {
 
     private final S3StorageService s3StorageService;
-    private final ClothesAiClient clothesAiClient;
     private final ClothesPhotoRepository clothesPhotoRepository;
+    private final ClothesPhotoAnalysisAsyncService clothesPhotoAnalysisAsyncService;
 
     public ClothesPhotoCreateResponse uploadAndAnalyze(Long memberId, MultipartFile image) {
+        byte[] imageBytes = toBytes(image);
+        String originalFilename = image.getOriginalFilename();
+        String contentType = image.getContentType();
 
         S3StorageService.SavedImage savedImage = s3StorageService.uploadClothesImage(image);
 
+        ClothesPhoto clothesPhoto = ClothesPhoto.builder()
+                .memberId(memberId)
+                .imageUrl(savedImage.getImageUrl())
+                .analysisStatus(AnalysisStatus.PENDING)
+                .predictedCategory(null)
+                .predictedColor(null)
+                .build();
+
+        ClothesPhoto savedPhoto = clothesPhotoRepository.save(clothesPhoto);
+
+        clothesPhotoAnalysisAsyncService.analyzeAsync(
+                savedPhoto.getId(),
+                imageBytes,
+                originalFilename,
+                contentType
+        );
+
+        return toResponse(savedPhoto);
+    }
+
+    public ClothesPhotoCreateResponse getAnalysisResult(Long memberId, Long photoId) {
+        ClothesPhoto clothesPhoto = clothesPhotoRepository.findByIdAndMemberId(photoId, memberId)
+                .orElseThrow(() -> new GeneralException(ClothesErrorCode.CLOTHES_PHOTO_NOT_FOUND));
+
+        return toResponse(clothesPhoto);
+    }
+
+    private ClothesPhotoCreateResponse toResponse(ClothesPhoto clothesPhoto) {
+        return new ClothesPhotoCreateResponse(
+                clothesPhoto.getId(),
+                clothesPhoto.getImageUrl(),
+                clothesPhoto.getAnalysisStatus(),
+                clothesPhoto.getPredictedCategory(),
+                clothesPhoto.getPredictedColor()
+        );
+    }
+
+    private byte[] toBytes(MultipartFile image) {
         try {
-            AiClothesPredictionResponse aiResult = clothesAiClient.predict(image);
-
-            if (aiResult == null || aiResult.results() == null || aiResult.results().isEmpty()) {
-                throw new IllegalStateException("AI 분석 결과가 없습니다.");
-            }
-
-            List<ResultDto> results = aiResult.results();
-            ResultDto firstResult = results.get(0);
-
-            String predictedCategory = firstResult.category();
-            String predictedColor = ColorMapper.toEnglish(firstResult.color());
-
-            ClothesPhoto clothesPhoto = ClothesPhoto.builder()
-                    .memberId(memberId)
-                    .imageUrl(savedImage.getImageUrl())
-                    .analysisStatus(AnalysisStatus.SUCCESS)
-                    .predictedCategory(predictedCategory)
-                    .predictedColor(predictedColor)
-                    .build();
-
-            ClothesPhoto savedPhoto = clothesPhotoRepository.save(clothesPhoto);
-
-            return new ClothesPhotoCreateResponse(
-                    savedPhoto.getId(),
-                    savedPhoto.getImageUrl(),
-                    savedPhoto.getAnalysisStatus(),
-                    savedPhoto.getPredictedCategory(),
-                    savedPhoto.getPredictedColor()
-            );
-
-        } catch (Exception e) {
-            ClothesPhoto failedPhoto = ClothesPhoto.builder()
-                    .memberId(memberId)
-                    .imageUrl(savedImage.getImageUrl())
-                    .analysisStatus(AnalysisStatus.FAIL)
-                    .predictedCategory(null)
-                    .predictedColor(null)
-                    .build();
-
-            ClothesPhoto savedPhoto = clothesPhotoRepository.save(failedPhoto);
-
-            return new ClothesPhotoCreateResponse(
-                    savedPhoto.getId(),
-                    savedPhoto.getImageUrl(),
-                    savedPhoto.getAnalysisStatus(),
-                    savedPhoto.getPredictedCategory(),
-                    savedPhoto.getPredictedColor()
-            );
+            return image.getBytes();
+        } catch (IOException e) {
+            throw new IllegalArgumentException("이미지 파일을 읽는 중 오류가 발생했습니다.");
         }
     }
 }

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/S3StorageService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/S3StorageService.java
@@ -9,11 +9,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class S3StorageService {
@@ -79,6 +82,17 @@ public class S3StorageService {
         String key = extractKey(imageUrl);
         if (key != null) {
             delete(key);
+        }
+    }
+
+    public void deleteByKey(String key) {
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build());
+        } catch (Exception e) {
+            log.warn("S3 객체 삭제 실패: key={}", key, e);
         }
     }
 

--- a/src/main/java/com/weartrack/backend/global/config/AsyncConfig.java
+++ b/src/main/java/com/weartrack/backend/global/config/AsyncConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 
 @Configuration
 public class AsyncConfig {
@@ -17,6 +18,9 @@ public class AsyncConfig {
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(50);
         executor.setThreadNamePrefix("ai-analysis-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
 
         executor.initialize();
         return executor;

--- a/src/main/java/com/weartrack/backend/global/config/AsyncConfig.java
+++ b/src/main/java/com/weartrack/backend/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.weartrack.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "aiAnalysisExecutor")
+    public Executor aiAnalysisExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("ai-analysis-");
+
+        executor.initialize();
+        return executor;
+    }
+}


### PR DESCRIPTION
## 작업 내용

기존 /api/clothes/photo API의 AI 분석 동기 처리 구조를 비동기 구조로 리팩토링했습니다.

기존에는:
사진 업로드 → S3 업로드 → AI 분석 완료까지 대기 → 응답

구조였기 때문에 배포 서버 환경에서 AI 응답 지연 시 타임아웃이 발생할 가능성이 있었습니다.

이를 개선하기 위해 업로드 직후 PENDING 상태를 반환하고,
AI 분석은 백그라운드에서 비동기로 수행하도록 수정했습니다.

---

## 변경 사항

### 1. 옷 사진 AI 분석 비동기 처리 적용
- `@EnableAsync` 추가
- `AsyncConfig` 추가
- `ClothesPhotoAnalysisAsyncService` 신규 생성

### 2. /api/clothes/photo 구조 변경
기존:
- AI 분석 완료까지 요청 대기

변경 후:
- 업로드 직후 `analysisStatus=PENDING` 반환
- 백그라운드에서 AI 분석 수행
- 분석 완료 후 DB 상태 업데이트

### 3. AI 분석 상태 조회 API 추가
추가 API:
GET `/api/clothes/photo/{photoId}/analysis`

- PENDING / SUCCESS / FAIL 상태 조회 가능
- SUCCESS 시 predictedCategory, predictedColor 반환

### 4. ClothesPhoto 엔티티 개선
- `markAnalysisSuccess()`
- `markAnalysisFail()`
메서드 추가

### 5. MultipartFile 비동기 처리 안정성 개선
- 비동기 작업 전에 `byte[]`로 복사하여 처리
- 요청 종료 후 MultipartFile 접근 문제 방지

### 6. Swagger 문서 반영
- 신규 analysis 조회 API 설명 추가
- 비동기 처리 구조 설명 추가

---

## 테스트 완료 사항

### 옷 사진 업로드
POST `/api/clothes/photo`

- 업로드 직후 PENDING 응답 확인
- 응답 속도 개선 확인

### AI 분석 상태 조회
GET `/api/clothes/photo/{photoId}/analysis`

- SUCCESS 상태 정상 반환 확인
- predictedCategory / predictedColor 정상 저장 확인

### 옷 추가 등록
POST `/api/clothes`

- AI 분석 결과 기반 category/color로 정상 등록 확인

### 옷장 등록
POST `/api/closets`

- sectionId 생성 및 clothes 등록 연동 확인

---

## 기대 효과

- 배포 환경 타임아웃 문제 완화
- AI 서버 지연이 전체 API 실패로 이어지는 문제 방지
- 사용자 경험 개선 (분석 중 상태 표시 가능)
- 향후 AI 분석 시간 증가에도 안정적 대응 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 옷 사진 업로드 시 즉시 완료 응답 제공 (분석 결과는 별도 조회 가능)
  * 분석 결과 조회 엔드포인트 추가

* **Improvements**
  * 옷 분류 및 색상 분석을 백그라운드에서 비동기로 처리하여 업로드 응답 속도 개선
  * 에러 처리 및 예외 메시지 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WEARTRACK/BE/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->