### PR TITLE
[Chore] Weartrack 모니터링 환경 구축 및 로깅 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 env
-
+logs
 HELP.md
 .gradle
 build/

--- a/build.gradle
+++ b/build.gradle
@@ -41,11 +41,17 @@ dependencies {
 
 	implementation platform('software.amazon.awssdk:bom:2.25.60')
 	implementation 'software.amazon.awssdk:s3'
+
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 
 	implementation 'org.springframework.retry:spring-retry'
 	implementation 'org.springframework:spring-aspects'
+
+	// prometheus
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/weartrack/backend/domain/clothes/controller/ClothesController.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/controller/ClothesController.java
@@ -80,7 +80,7 @@ public class ClothesController {
 
     @Operation(
             summary = "옷 정보 수정",
-            description = "옷의 색상, 카테고리, 가격, 섹션을 수정합니다. 변경하지 않을 필드는 null로 보내면 됩니다."
+            description = "가격, 섹션을 수정합니다. 변경하지 않을 필드는 null로 보내면 됩니다."
     )
     @PatchMapping("/{clothesId}")
     public ApiResponse<ClothesDetailResDto> updateClothes(

--- a/src/main/java/com/weartrack/backend/domain/clothes/dto/request/ClothesUpdateRequest.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/dto/request/ClothesUpdateRequest.java
@@ -3,8 +3,6 @@ package com.weartrack.backend.domain.clothes.dto.request;
 import jakarta.validation.constraints.Min;
 
 public record ClothesUpdateRequest(
-        String color,
-        String category,
        @Min(0) Integer price,
         Long sectionId
 ) {

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesService.java
@@ -132,16 +132,6 @@ public class ClothesService {
             throw new GeneralException(ClothesErrorCode.CLOTHES_NOT_OWNED);
         }
 
-        if (request.color() != null && request.color().isBlank()) {
-            throw new IllegalArgumentException("color는 공백일 수 없습니다.");
-        }
-
-        if (request.category() != null && request.category().isBlank()) {
-            throw new IllegalArgumentException("category는 공백일 수 없습니다.");
-        }
-
-        clothes.updateColor(request.color());
-        clothes.updateCategory(request.category());
         clothes.updatePrice(request.price());
 
         ClosetSection finalSection = currentSection;

--- a/src/main/java/com/weartrack/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/weartrack/backend/global/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    @Value("${app.cors.allowed-origins:https://wear-track.com,https://weartrack.co.kr,https://monitor.wear-track.com}")
+    @Value("${app.cors.allowed-origins:https://wear-track.com,https://weartrack.co.kr}")
     private List<String> allowedOrigins;
 
     /**

--- a/src/main/java/com/weartrack/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/weartrack/backend/global/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    @Value("${app.cors.allowed-origins:https://wear-track.com,https://weartrack.co.kr}")
+    @Value("${app.cors.allowed-origins:https://wear-track.com,https://weartrack.co.kr,https://monitor.wear-track.com}")
     private List<String> allowedOrigins;
 
     /**
@@ -45,6 +45,7 @@ public class SecurityConfig {
                                 "/",
                                 "/index.html",
                                 "/actuator/health",
+                                "/actuator/prometheus",
                                 "/api/auth/social/authorize/*",
                                 "/api/auth/social/login",
                                 "/login/oauth2/code/google",

--- a/src/main/java/com/weartrack/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/weartrack/backend/global/exception/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ package com.weartrack.backend.global.exception;
 import com.weartrack.backend.global.exception.code.BaseErrorCode;
 import com.weartrack.backend.global.exception.code.GlobalErrorCode;
 import com.weartrack.backend.global.response.ApiResponse;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -81,14 +80,8 @@ public class GlobalExceptionHandler {
      * 존재하지 않는 경로(매핑된 핸들러·정적 리소스 없음) 요청을 404 응답으로 변환한다.
      */
     @ExceptionHandler(NoResourceFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleNoResourceFoundException(
-            NoResourceFoundException e, HttpServletRequest request) {
-        log.warn("No resource found: method={}, uri={}, ua={}, ip={}, xff={}",
-                request.getMethod(),
-                request.getRequestURI(),
-                request.getHeader("User-Agent"),
-                request.getRemoteAddr(),
-                request.getHeader("X-Forwarded-For"));
+    public ResponseEntity<ApiResponse<Void>> handleNoResourceFoundException(NoResourceFoundException e) {
+        log.debug("No resource found: {}", e.getResourcePath());
 
         GlobalErrorCode errorCode = GlobalErrorCode.NOT_FOUND;
         return ResponseEntity

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,7 +13,7 @@ spring:
   jpa:
     database: mysql # 사용하는 데이터베이스 타입입니다.
     database-platform: org.hibernate.dialect.MySQLDialect
-    show-sql: true # 실행된 SQL을 콘솔에 출력합니다.
+    show-sql: false # 실행된 SQL을 콘솔에 출력합니다.
     hibernate:
       ddl-auto: update # 애플리케이션 실행 시 스키마를 반영합니다.
     properties:
@@ -58,13 +58,47 @@ file:
   upload-dir: uploads
 
 cloud:
-   aws:
-     region: ${AWS_REGION:ap-northeast-2}
-     s3:
-       bucket: ${AWS_S3_BUCKET}
-     credentials:
-       access-key: ${AWS_ACCESS_KEY}
-       secret-key: ${AWS_SECRET_KEY}
+  aws:
+    region: ${AWS_REGION:ap-northeast-2}
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
 
 ai:
   base-url: ${AI_BASE_URL}
+
+logging:
+  level:
+    root: INFO
+    # Weartrack 내부 비즈니스 로직 로그는 상세하게(DEBUG) 확인
+    com.weartrack: DEBUG
+
+    # 커스텀 예외 처리기에서 발생하는 NoResourceFoundException 관련 WARN 로그 숨기기
+    com.weartrack.backend.global.exception.GlobalExceptionHandler: ERROR
+    # Spring MVC 내부 예외 처리기에서 발생하는 WARN 로그 숨기기
+    org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver: ERROR
+
+  file:
+    # 서버 에러 추적을 위해 로그를 파일로 저장
+    name: ./logs/weartrack-application.log
+  logback:
+    rollingpolicy:
+      max-history: 30 # 최대 30일치 로그 보관
+      max-file-size: 10MB # 파일 하나당 최대 10MB 유지
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true
+  metrics:
+    tags:
+      # 프로메테우스 수집 시 구분할 서버 고유 이름표 설정
+      application: weartrack-spring-boot

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -72,7 +72,7 @@ ai:
 logging:
   level:
     root: INFO
-    # Weartrack 내부 비즈니스 로직 로그는 상세하게(DEBUG) 확인
+    # Weartrack 내부 비즈니스 로직 로그는 상세하게 확인
     com.weartrack: DEBUG
 
     # 커스텀 예외 처리기에서 발생하는 NoResourceFoundException 관련 WARN 로그 숨기기
@@ -95,10 +95,10 @@ management:
         include: health, info, prometheus
   endpoint:
     health:
-      show-details: always
+      show-details: when-authorized
     prometheus:
       enabled: true
   metrics:
     tags:
-      # 프로메테우스 수집 시 구분할 서버 고유 이름표 설정
+      # 프로메테우스 수집 시 구분할 서버 고유 이름표 설정zh
       application: weartrack-spring-boot


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#38 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 실시간 서버 리소스(CPU, 메모리) 및 애플리케이션 상태(DB 커넥션, 스레드 풀 등)를 파악하여 안정적인 Weartrack 서비스를 운영하기 위해 모니터링 시스템을 도입합니다.
- 장애 발생 시 원인 추적을 용이하게 하기 위해 서버 내부에 파일 형태로 로그를 남기는 롤링 로깅(Rolling Logging) 설정을 추가합니다.
1. `SecurityConfig.java`: 프로메테우스 수집을 위한 `/actuator/prometheus` 엔드포인트 접근 권한 개방
2.  `application.yml`: Actuator 지표 노출 및 Weartrack 애플리케이션 식별 태그 추가
3.  `application.yml`: Logback 설정 추가 (최대 30일 보관, 10MB 분할 파일 저장)

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

- 테스트 방법
1. `https://monitor.wear-track.com` 접속 시 Grafana 로그인 화면 정상 노출 확인
2. Grafana 대시보드 내 JVM 메트릭 및 HikariCP 지표 실시간 수집 확인
3. 서버 터미널 내부 `./logs/weartrack-application.log` 파일 생성 및 기록 확인

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **인프라 개선**
  * Prometheus 모니터링 의존성이 추가되고 프로덕션에 모니터링·관리 설정이 적용되었습니다.

* **보안**
  * Prometheus 관련 관리 엔드포인트에 인증 없이 접근 가능하도록 보안 설정이 조정되었습니다.

* **로깅 개선**
  * 실행 SQL 출력 비활성화 및 로그 레벨·파일 설정이 조정되어 로그 출력이 최적화되었습니다.

* **API 변경**
  * 상품 수정 API가 간소화되어 업데이트 가능한 필드가 가격 및 섹션으로 제한되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->