### PR TITLE
feat: 쇼핑몰 링크 기반 옷 등록 기능 추가

### DIFF
--- a/src/main/java/com/weartrack/backend/domain/clothes/controller/ProductLinkController.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/controller/ProductLinkController.java
@@ -1,0 +1,39 @@
+package com.weartrack.backend.domain.clothes.controller;
+
+import com.weartrack.backend.domain.clothes.dto.request.ClothesFromLinkRequest;
+import com.weartrack.backend.domain.clothes.dto.request.ProductLinkPreviewRequest;
+import com.weartrack.backend.domain.clothes.dto.response.ClothesCreateResponse;
+import com.weartrack.backend.domain.clothes.dto.response.ProductLinkPreviewResponse;
+import com.weartrack.backend.domain.clothes.service.ProductLinkService;
+import com.weartrack.backend.global.response.ApiResponse;
+import com.weartrack.backend.global.security.JwtPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/clothes")
+public class ProductLinkController {
+
+    private final ProductLinkService productLinkService;
+
+    @PostMapping("/link-preview")
+    public ApiResponse<ProductLinkPreviewResponse> preview(
+            @Valid @RequestBody ProductLinkPreviewRequest request
+    ) {
+        return ApiResponse.success(productLinkService.preview(request));
+    }
+
+    @PostMapping("/from-link")
+    public ApiResponse<ClothesCreateResponse> createFromLink(
+            @AuthenticationPrincipal JwtPrincipal principal,
+            @Valid @RequestBody ClothesFromLinkRequest request
+    ) {
+        return ApiResponse.success(productLinkService.createFromLink(principal.memberId(), request));
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/dto/request/ClothesFromLinkRequest.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/dto/request/ClothesFromLinkRequest.java
@@ -14,11 +14,11 @@ public record ClothesFromLinkRequest(
         String productName,
 
         @NotBlank(message = "상품 원본 URL은 필수입니다.")
-        @Pattern(regexp = "^https?://.+", message = "상품 원본 URL은 http 또는 https 형식이어야 합니다.")
+        @Pattern(regexp = "^https?://\\S+$", message = "상품 원본 URL은 http 또는 https 형식이어야 합니다.")
         String sourceUrl,
 
         @NotBlank(message = "이미지 URL은 필수입니다.")
-        @Pattern(regexp = "^https?://.+", message = "이미지 URL은 http 또는 https 형식이어야 합니다.")
+        @Pattern(regexp = "^https?://\\S+$", message = "이미지 URL은 http 또는 https 형식이어야 합니다.")
         String imageUrl,
 
         @NotNull(message = "이미지 저장 타입은 필수입니다.")

--- a/src/main/java/com/weartrack/backend/domain/clothes/dto/request/ClothesFromLinkRequest.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/dto/request/ClothesFromLinkRequest.java
@@ -1,0 +1,44 @@
+package com.weartrack.backend.domain.clothes.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.weartrack.backend.domain.clothes.entity.ImageStorageType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import java.time.LocalDate;
+
+public record ClothesFromLinkRequest(
+        @NotBlank(message = "상품명은 필수입니다.")
+        String productName,
+
+        @NotBlank(message = "상품 원본 URL은 필수입니다.")
+        @Pattern(regexp = "^https?://.+", message = "상품 원본 URL은 http 또는 https 형식이어야 합니다.")
+        String sourceUrl,
+
+        @NotBlank(message = "이미지 URL은 필수입니다.")
+        @Pattern(regexp = "^https?://.+", message = "이미지 URL은 http 또는 https 형식이어야 합니다.")
+        String imageUrl,
+
+        @NotNull(message = "이미지 저장 타입은 필수입니다.")
+        @JsonAlias("imageType")
+        ImageStorageType imageStorageType,
+
+        @NotBlank(message = "색상은 필수입니다.")
+        String color,
+
+        @NotBlank(message = "카테고리는 필수입니다.")
+        String category,
+
+        @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
+        Integer price,
+
+        LocalDate purchaseDate,
+
+        String storageLocation,
+
+        @NotNull(message = "옷장 sectionId는 필수입니다.")
+        Long sectionId
+) {
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/dto/request/ProductLinkPreviewRequest.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/dto/request/ProductLinkPreviewRequest.java
@@ -1,0 +1,9 @@
+package com.weartrack.backend.domain.clothes.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ProductLinkPreviewRequest(
+        @NotBlank(message = "상품 URL은 필수입니다.")
+        String url
+) {
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/dto/response/ClothesCreateResponse.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/dto/response/ClothesCreateResponse.java
@@ -1,14 +1,18 @@
 package com.weartrack.backend.domain.clothes.dto.response;
 
 import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public record ClothesCreateResponse(
         Long clothesId,
         Long photoId,
         String imageUrl,
+        String productName,
         String color,
         String category,
         Integer price,
+        LocalDate purchaseDate,
+        String storageLocation,
         Long sectionId,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/weartrack/backend/domain/clothes/dto/response/ClothesDetailResDto.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/dto/response/ClothesDetailResDto.java
@@ -6,9 +6,12 @@ import com.weartrack.backend.domain.clothes.entity.Clothes;
 public record ClothesDetailResDto(
         Long clothesId,
         String imageUrl,
+        String productName,
         String color,
         String category,
         Integer price,
+        java.time.LocalDate purchaseDate,
+        String storageLocation,
         Long sectionId,
         String sectionName
 ) {
@@ -16,9 +19,12 @@ public record ClothesDetailResDto(
         return new ClothesDetailResDto(
                 clothes.getId(),
                 clothes.getImageUrl(),
+                clothes.getProductName(),
                 clothes.getColor(),
                 clothes.getCategory(),
                 clothes.getPrice(),
+                clothes.getPurchaseDate(),
+                clothes.getStorageLocation(),
                 section.getSectionId(),
                 section.getSectionName()
         );

--- a/src/main/java/com/weartrack/backend/domain/clothes/dto/response/ProductLinkPreviewResponse.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/dto/response/ProductLinkPreviewResponse.java
@@ -1,0 +1,16 @@
+package com.weartrack.backend.domain.clothes.dto.response;
+
+import com.weartrack.backend.domain.clothes.entity.SourceShop;
+
+public record ProductLinkPreviewResponse(
+        SourceShop sourceShop,
+        String sourceUrl,
+        String productName,
+        String imageUrl,
+        Integer price,
+        String brandName,
+        String category,
+        String color,
+        String reasonCode
+) {
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/entity/AnalysisStatus.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/entity/AnalysisStatus.java
@@ -3,5 +3,6 @@ package com.weartrack.backend.domain.clothes.entity;
 public enum AnalysisStatus {
     PENDING,
     SUCCESS,
-    FAIL
+    FAIL,
+    SKIPPED
 }

--- a/src/main/java/com/weartrack/backend/domain/clothes/entity/Clothes.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/entity/Clothes.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 @Table(name = "clothes")
@@ -27,6 +28,9 @@ public class Clothes {
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
+    @Column(name = "product_name")
+    private String productName;
+
     @Column(name = "color", nullable = false)
     private String color;
 
@@ -35,6 +39,12 @@ public class Clothes {
 
     @Column(name = "price")
     private Integer price;
+
+    @Column(name = "purchase_date")
+    private LocalDate purchaseDate;
+
+    @Column(name = "storage_location", length = 100)
+    private String storageLocation;
 
     @Column(name = "created_at")
     private LocalDateTime createdAt;

--- a/src/main/java/com/weartrack/backend/domain/clothes/entity/ClothesPhoto.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/entity/ClothesPhoto.java
@@ -25,6 +25,18 @@ public class ClothesPhoto {
     private String imageUrl;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "image_storage_type", nullable = false)
+    @Builder.Default
+    private ImageStorageType imageStorageType = ImageStorageType.USER_UPLOAD;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_shop")
+    private SourceShop sourceShop;
+
+    @Column(name = "source_url", length = 1000)
+    private String sourceUrl;
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "analysis_status", nullable = false)
     private AnalysisStatus analysisStatus;
 

--- a/src/main/java/com/weartrack/backend/domain/clothes/entity/ImageStorageType.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/entity/ImageStorageType.java
@@ -1,0 +1,6 @@
+package com.weartrack.backend.domain.clothes.entity;
+
+public enum ImageStorageType {
+    USER_UPLOAD,
+    EXTERNAL_URL
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/entity/SourceShop.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/entity/SourceShop.java
@@ -1,0 +1,8 @@
+package com.weartrack.backend.domain.clothes.entity;
+
+public enum SourceShop {
+    MUSINSA,
+    ABLY,
+    ZIGZAG,
+    UNKNOWN
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/exception/ClothesErrorCode.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/exception/ClothesErrorCode.java
@@ -37,6 +37,36 @@ public enum ClothesErrorCode implements BaseErrorCode {
             "CLOTHES_PHOTO_4003",
             "이미지 파일을 읽는 중 오류가 발생했습니다.",
             HttpStatus.BAD_REQUEST
+    ),
+
+    PRODUCT_LINK_INVALID_URL(
+            "PRODUCT_LINK_4001",
+            "잘못된 상품 URL입니다.",
+            HttpStatus.BAD_REQUEST
+    ),
+
+    PRODUCT_LINK_UNSUPPORTED_URL(
+            "PRODUCT_LINK_4002",
+            "지원하지 않는 URL 형식입니다.",
+            HttpStatus.BAD_REQUEST
+    ),
+
+    PRODUCT_LINK_FETCH_FAILED(
+            "PRODUCT_LINK_4003",
+            "상품 정보를 불러올 수 없습니다. 상품 페이지를 확인하거나 직접 입력해 주세요.",
+            HttpStatus.BAD_REQUEST
+    ),
+
+    PRODUCT_LINK_PARSE_FAILED(
+            "PRODUCT_LINK_4004",
+            "상품 정보를 불러올 수 없습니다. 상품 페이지를 확인하거나 직접 입력해 주세요.",
+            HttpStatus.BAD_REQUEST
+    ),
+
+    PRODUCT_LINK_DUPLICATED(
+            "PRODUCT_LINK_4005",
+            "이미 등록된 상품 링크입니다.",
+            HttpStatus.CONFLICT
     );
 
     private final String code;

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/ProductPage.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/ProductPage.java
@@ -1,0 +1,7 @@
+package com.weartrack.backend.domain.clothes.link;
+
+public record ProductPage(
+        String url,
+        String html
+) {
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/ProductPageFetcher.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/ProductPageFetcher.java
@@ -1,0 +1,114 @@
+package com.weartrack.backend.domain.clothes.link;
+
+import com.weartrack.backend.domain.clothes.exception.ClothesErrorCode;
+import com.weartrack.backend.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class ProductPageFetcher {
+
+    private static final int MAX_HTML_BYTES = 1_000_000;
+    private static final int MAX_REDIRECTS = 3;
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+    private final UrlSafetyValidator urlSafetyValidator;
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(3))
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build();
+
+    public ProductPage fetch(String url) {
+        String currentUrl = url;
+        for (int redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
+            urlSafetyValidator.validate(currentUrl);
+            HttpResponse<InputStream> response = send(currentUrl);
+
+            int statusCode = response.statusCode();
+            if (statusCode >= 300 && statusCode < 400) {
+                currentUrl = resolveRedirectUrl(currentUrl, response);
+                continue;
+            }
+            if (statusCode < 200 || statusCode >= 300) {
+                throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_FETCH_FAILED);
+            }
+
+            return new ProductPage(currentUrl, readLimitedHtml(response));
+        }
+
+        throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_FETCH_FAILED);
+    }
+
+    private HttpResponse<InputStream> send(String url) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                    .timeout(REQUEST_TIMEOUT)
+                    .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36")
+                    .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
+                    .header("Accept-Language", "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7")
+                    .GET()
+                    .build();
+            return httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        } catch (Exception e) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_FETCH_FAILED);
+        }
+    }
+
+    private String resolveRedirectUrl(String currentUrl, HttpResponse<InputStream> response) {
+        Optional<String> location = response.headers().firstValue("Location");
+        if (location.isEmpty()) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_FETCH_FAILED);
+        }
+        return URI.create(currentUrl).resolve(location.get()).toString();
+    }
+
+    private String readLimitedHtml(HttpResponse<InputStream> response) {
+        try (InputStream inputStream = response.body();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[8192];
+            int totalBytes = 0;
+            int readBytes;
+            while ((readBytes = inputStream.read(buffer)) != -1) {
+                totalBytes += readBytes;
+                if (totalBytes > MAX_HTML_BYTES) {
+                    throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_FETCH_FAILED);
+                }
+                outputStream.write(buffer, 0, readBytes);
+            }
+
+            return outputStream.toString(resolveCharset(response));
+        } catch (GeneralException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_FETCH_FAILED);
+        }
+    }
+
+    private Charset resolveCharset(HttpResponse<InputStream> response) {
+        String contentType = response.headers().firstValue("Content-Type").orElse("");
+        for (String part : contentType.split(";")) {
+            String trimmedPart = part.trim();
+            if (trimmedPart.toLowerCase().startsWith("charset=")) {
+                try {
+                    return Charset.forName(trimmedPart.substring("charset=".length()));
+                } catch (Exception ignored) {
+                    return StandardCharsets.UTF_8;
+                }
+            }
+        }
+        return StandardCharsets.UTF_8;
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/ProductPageFetcher.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/ProductPageFetcher.java
@@ -102,8 +102,15 @@ public class ProductPageFetcher {
         for (String part : contentType.split(";")) {
             String trimmedPart = part.trim();
             if (trimmedPart.toLowerCase().startsWith("charset=")) {
+                String charsetValue = trimmedPart.substring("charset=".length())
+                        .trim()
+                        .replace("\"", "")
+                        .replace("'", "");
+                if (charsetValue.isEmpty()) {
+                    return StandardCharsets.UTF_8;
+                }
                 try {
-                    return Charset.forName(trimmedPart.substring("charset=".length()));
+                    return Charset.forName(charsetValue);
                 } catch (Exception ignored) {
                     return StandardCharsets.UTF_8;
                 }

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/ProductParseResult.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/ProductParseResult.java
@@ -1,0 +1,33 @@
+package com.weartrack.backend.domain.clothes.link;
+
+public record ProductParseResult(
+        String productName,
+        String imageUrl,
+        String description,
+        String canonicalUrl,
+        Integer price,
+        String brandName,
+        String category,
+        String color
+) {
+    public ProductParseResult merge(ProductParseResult fallback) {
+        if (fallback == null) {
+            return this;
+        }
+
+        return new ProductParseResult(
+                firstNonBlank(productName, fallback.productName),
+                firstNonBlank(imageUrl, fallback.imageUrl),
+                firstNonBlank(description, fallback.description),
+                firstNonBlank(canonicalUrl, fallback.canonicalUrl),
+                price != null ? price : fallback.price,
+                firstNonBlank(brandName, fallback.brandName),
+                firstNonBlank(category, fallback.category),
+                firstNonBlank(color, fallback.color)
+        );
+    }
+
+    private static String firstNonBlank(String value, String fallback) {
+        return value != null && !value.isBlank() ? value : fallback;
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/ProductParser.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/ProductParser.java
@@ -1,0 +1,10 @@
+package com.weartrack.backend.domain.clothes.link;
+
+import com.weartrack.backend.domain.clothes.entity.SourceShop;
+
+public interface ProductParser {
+
+    boolean supports(SourceShop sourceShop);
+
+    ProductParseResult parse(String html, String pageUrl);
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/ProductUrlNormalizer.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/ProductUrlNormalizer.java
@@ -55,6 +55,7 @@ public class ProductUrlNormalizer {
         }
 
         String query = Arrays.stream(rawQuery.split("&"))
+                .filter(parameter -> !parameter.isBlank())
                 .filter(parameter -> !isTrackingParameter(parameter))
                 .collect(Collectors.joining("&"));
 
@@ -63,10 +64,17 @@ public class ProductUrlNormalizer {
 
     private boolean isTrackingParameter(String parameter) {
         String key = parameter.split("=", 2)[0];
-        String decodedKey = URLDecoder.decode(key, StandardCharsets.UTF_8)
-                .toLowerCase(Locale.ROOT);
+        String decodedKey = safeDecode(key).toLowerCase(Locale.ROOT);
         return decodedKey.startsWith("utm_")
                 || decodedKey.equals("fbclid")
                 || decodedKey.equals("gclid");
+    }
+
+    private String safeDecode(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            return value;
+        }
     }
 }

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/ProductUrlNormalizer.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/ProductUrlNormalizer.java
@@ -1,0 +1,72 @@
+package com.weartrack.backend.domain.clothes.link;
+
+import com.weartrack.backend.domain.clothes.exception.ClothesErrorCode;
+import com.weartrack.backend.global.exception.GeneralException;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+@Component
+public class ProductUrlNormalizer {
+
+    public String normalize(String rawUrl) {
+        URI uri = toUri(rawUrl);
+        String scheme = uri.getScheme();
+        if (scheme == null || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_INVALID_URL);
+        }
+        if (uri.getHost() == null) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_INVALID_URL);
+        }
+
+        try {
+            return new URI(
+                    scheme.toLowerCase(Locale.ROOT),
+                    uri.getUserInfo(),
+                    uri.getHost().toLowerCase(Locale.ROOT),
+                    uri.getPort(),
+                    uri.getRawPath(),
+                    normalizeQuery(uri.getRawQuery()),
+                    null
+            ).toString();
+        } catch (URISyntaxException e) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_INVALID_URL);
+        }
+    }
+
+    private URI toUri(String rawUrl) {
+        try {
+            return new URI(rawUrl.trim());
+        } catch (Exception e) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_INVALID_URL);
+        }
+    }
+
+    private String normalizeQuery(String rawQuery) {
+        if (rawQuery == null || rawQuery.isBlank()) {
+            return null;
+        }
+
+        String query = Arrays.stream(rawQuery.split("&"))
+                .filter(parameter -> !isTrackingParameter(parameter))
+                .collect(Collectors.joining("&"));
+
+        return query.isBlank() ? null : query;
+    }
+
+    private boolean isTrackingParameter(String parameter) {
+        String key = parameter.split("=", 2)[0];
+        String decodedKey = URLDecoder.decode(key, StandardCharsets.UTF_8)
+                .toLowerCase(Locale.ROOT);
+        return decodedKey.startsWith("utm_")
+                || decodedKey.equals("fbclid")
+                || decodedKey.equals("gclid");
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/SourceShopResolver.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/SourceShopResolver.java
@@ -16,15 +16,20 @@ public class SourceShopResolver {
         }
 
         String normalizedHost = host.toLowerCase(Locale.ROOT);
-        if (normalizedHost.contains("musinsa.com")) {
+        if (isSameOrSubdomain(normalizedHost, "musinsa.com")) {
             return SourceShop.MUSINSA;
         }
-        if (normalizedHost.contains("a-bly.com") || normalizedHost.contains("ably.team")) {
+        if (isSameOrSubdomain(normalizedHost, "a-bly.com")
+                || isSameOrSubdomain(normalizedHost, "ably.team")) {
             return SourceShop.ABLY;
         }
-        if (normalizedHost.contains("zigzag.kr")) {
+        if (isSameOrSubdomain(normalizedHost, "zigzag.kr")) {
             return SourceShop.ZIGZAG;
         }
         return SourceShop.UNKNOWN;
+    }
+
+    private boolean isSameOrSubdomain(String host, String domain) {
+        return host.equals(domain) || host.endsWith("." + domain);
     }
 }

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/SourceShopResolver.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/SourceShopResolver.java
@@ -1,0 +1,30 @@
+package com.weartrack.backend.domain.clothes.link;
+
+import com.weartrack.backend.domain.clothes.entity.SourceShop;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.Locale;
+
+@Component
+public class SourceShopResolver {
+
+    public SourceShop resolve(String url) {
+        String host = URI.create(url).getHost();
+        if (host == null) {
+            return SourceShop.UNKNOWN;
+        }
+
+        String normalizedHost = host.toLowerCase(Locale.ROOT);
+        if (normalizedHost.contains("musinsa.com")) {
+            return SourceShop.MUSINSA;
+        }
+        if (normalizedHost.contains("a-bly.com") || normalizedHost.contains("ably.team")) {
+            return SourceShop.ABLY;
+        }
+        if (normalizedHost.contains("zigzag.kr")) {
+            return SourceShop.ZIGZAG;
+        }
+        return SourceShop.UNKNOWN;
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/UrlSafetyValidator.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/UrlSafetyValidator.java
@@ -1,0 +1,71 @@
+package com.weartrack.backend.domain.clothes.link;
+
+import com.weartrack.backend.domain.clothes.exception.ClothesErrorCode;
+import com.weartrack.backend.global.exception.GeneralException;
+import org.springframework.stereotype.Component;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.Locale;
+
+@Component
+public class UrlSafetyValidator {
+
+    public void validate(String url) {
+        URI uri = toUri(url);
+        String scheme = uri.getScheme();
+        if (scheme == null || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_INVALID_URL);
+        }
+
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_INVALID_URL);
+        }
+
+        String normalizedHost = host.toLowerCase(Locale.ROOT);
+        if (normalizedHost.equals("localhost") || normalizedHost.endsWith(".localhost")) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_UNSUPPORTED_URL);
+        }
+
+        try {
+            for (InetAddress address : InetAddress.getAllByName(host)) {
+                if (isBlockedAddress(address)) {
+                    throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_UNSUPPORTED_URL);
+                }
+            }
+        } catch (GeneralException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_FETCH_FAILED);
+        }
+    }
+
+    private URI toUri(String url) {
+        try {
+            return URI.create(url);
+        } catch (Exception e) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_INVALID_URL);
+        }
+    }
+
+    private boolean isBlockedAddress(InetAddress address) {
+        return address.isAnyLocalAddress()
+                || address.isLoopbackAddress()
+                || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress()
+                || address.isMulticastAddress()
+                || isCarrierGradeNat(address);
+    }
+
+    private boolean isCarrierGradeNat(InetAddress address) {
+        if (!(address instanceof Inet4Address)) {
+            return false;
+        }
+        byte[] bytes = address.getAddress();
+        int first = bytes[0] & 0xff;
+        int second = bytes[1] & 0xff;
+        return first == 100 && second >= 64 && second <= 127;
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/parser/AblyParser.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/parser/AblyParser.java
@@ -1,0 +1,72 @@
+package com.weartrack.backend.domain.clothes.link.parser;
+
+import com.weartrack.backend.domain.clothes.entity.SourceShop;
+import com.weartrack.backend.domain.clothes.link.ProductParseResult;
+import com.weartrack.backend.domain.clothes.link.ProductParser;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class AblyParser implements ProductParser {
+
+    private static final Pattern WON_PRICE_PATTERN = Pattern.compile("([0-9]{1,3}(?:,[0-9]{3})+)\\s*원");
+
+    @Override
+    public boolean supports(SourceShop sourceShop) {
+        return sourceShop == SourceShop.ABLY;
+    }
+
+    @Override
+    public ProductParseResult parse(String html, String pageUrl) {
+        String title = HtmlMetaExtractor.findMetaContent(html, "og:title")
+                .or(() -> HtmlMetaExtractor.findMetaContent(html, "twitter:title"))
+                .orElse(null);
+        String description = HtmlMetaExtractor.findMetaContent(html, "og:description")
+                .or(() -> HtmlMetaExtractor.findMetaContent(html, "description"))
+                .or(() -> HtmlMetaExtractor.findMetaContent(html, "twitter:description"))
+                .orElse(null);
+
+        return new ProductParseResult(
+                cleanTitle(title),
+                HtmlMetaExtractor.findMetaContent(html, "og:image")
+                        .or(() -> HtmlMetaExtractor.findMetaContent(html, "twitter:image"))
+                        .orElse(null),
+                description,
+                HtmlMetaExtractor.findMetaContent(html, "og:url").orElse(pageUrl),
+                parsePrice(firstNonBlank(description, title)),
+                null,
+                null,
+                ColorKeywordMapper.infer(firstNonBlank(title, description))
+        );
+    }
+
+    private String cleanTitle(String title) {
+        if (title == null || title.isBlank()) {
+            return null;
+        }
+        return title
+                .replaceAll("\\s*[-|]\\s*에이블리.*$", "")
+                .trim();
+    }
+
+    private Integer parsePrice(String text) {
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+        Matcher matcher = WON_PRICE_PATTERN.matcher(text);
+        if (!matcher.find()) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(matcher.group(1).replace(",", ""));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String firstNonBlank(String value, String fallback) {
+        return value != null && !value.isBlank() ? value : fallback;
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/parser/ColorKeywordMapper.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/parser/ColorKeywordMapper.java
@@ -1,0 +1,62 @@
+package com.weartrack.backend.domain.clothes.link.parser;
+
+import java.util.Map;
+
+final class ColorKeywordMapper {
+
+    private static final Map<String, String> COLOR_MAP = Map.ofEntries(
+            Map.entry("\ube14\ub799", "Black"),
+            Map.entry("black", "Black"),
+            Map.entry("\ud654\uc774\ud2b8", "White"),
+            Map.entry("white", "White"),
+            Map.entry("\uc624\ud504\ud654\uc774\ud2b8", "White"),
+            Map.entry("\uc544\uc774\ubcf4\ub9ac", "Beige"),
+            Map.entry("ivory", "Beige"),
+            Map.entry("\ud06c\ub9bc", "Beige"),
+            Map.entry("cream", "Beige"),
+            Map.entry("\uc624\ud2b8\ubc00", "Beige"),
+            Map.entry("\ubca0\uc774\uc9c0", "Beige"),
+            Map.entry("beige", "Beige"),
+            Map.entry("\ube0c\ub77c\uc6b4", "Brown"),
+            Map.entry("brown", "Brown"),
+            Map.entry("\uadf8\ub808\uc774", "Gray"),
+            Map.entry("gray", "Gray"),
+            Map.entry("grey", "Gray"),
+            Map.entry("\ucc28\ucf5c", "Gray"),
+            Map.entry("\ub124\uc774\ube44", "Navy"),
+            Map.entry("navy", "Navy"),
+            Map.entry("\ube14\ub8e8", "Blue"),
+            Map.entry("blue", "Blue"),
+            Map.entry("\uc2a4\uce74\uc774", "Blue"),
+            Map.entry("\uc778\ub514\uace0", "Blue"),
+            Map.entry("\ub370\ub2d8", "Blue"),
+            Map.entry("\ub808\ub4dc", "Red"),
+            Map.entry("red", "Red"),
+            Map.entry("\ud551\ud06c", "Pink"),
+            Map.entry("pink", "Pink"),
+            Map.entry("\uc610\ub85c\uc6b0", "Yellow"),
+            Map.entry("yellow", "Yellow"),
+            Map.entry("\uadf8\ub9b0", "Green"),
+            Map.entry("green", "Green"),
+            Map.entry("\uce74\ud0a4", "Green"),
+            Map.entry("\ud37c\ud50c", "Purple"),
+            Map.entry("purple", "Purple"),
+            Map.entry("\uc624\ub80c\uc9c0", "Orange"),
+            Map.entry("orange", "Orange")
+    );
+
+    private ColorKeywordMapper() {
+    }
+
+    static String infer(String text) {
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+        String normalized = text.toLowerCase();
+        return COLOR_MAP.entrySet().stream()
+                .filter(entry -> normalized.contains(entry.getKey().toLowerCase()))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/parser/CommonOgParser.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/parser/CommonOgParser.java
@@ -1,0 +1,40 @@
+package com.weartrack.backend.domain.clothes.link.parser;
+
+import com.weartrack.backend.domain.clothes.entity.SourceShop;
+import com.weartrack.backend.domain.clothes.link.ProductParseResult;
+import com.weartrack.backend.domain.clothes.link.ProductParser;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommonOgParser implements ProductParser {
+
+    @Override
+    public boolean supports(SourceShop sourceShop) {
+        return true;
+    }
+
+    @Override
+    public ProductParseResult parse(String html, String pageUrl) {
+        return new ProductParseResult(
+                HtmlMetaExtractor.findMetaContent(html, "og:title").orElse(null),
+                HtmlMetaExtractor.findMetaContent(html, "og:image").orElse(null),
+                HtmlMetaExtractor.findMetaContent(html, "og:description").orElse(null),
+                HtmlMetaExtractor.findMetaContent(html, "og:url").orElse(pageUrl),
+                HtmlMetaExtractor.findMetaContent(html, "product:price:amount")
+                        .map(this::parsePrice)
+                        .orElse(null),
+                HtmlMetaExtractor.findMetaContent(html, "product:brand").orElse(null),
+                null,
+                null
+        );
+    }
+
+    private Integer parsePrice(String priceText) {
+        try {
+            String digitsOnly = priceText.replaceAll("[^0-9]", "");
+            return digitsOnly.isBlank() ? null : Integer.parseInt(digitsOnly);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/parser/HtmlMetaExtractor.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/parser/HtmlMetaExtractor.java
@@ -1,0 +1,57 @@
+package com.weartrack.backend.domain.clothes.link.parser;
+
+import org.springframework.web.util.HtmlUtils;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class HtmlMetaExtractor {
+
+    private static final Pattern META_TAG_PATTERN = Pattern.compile("<meta\\b[^>]*>", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ATTR_PATTERN = Pattern.compile(
+            "([a-zA-Z_:.-]+)\\s*=\\s*(\"([^\"]*)\"|'([^']*)'|([^\\s\"'>]+))",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    private HtmlMetaExtractor() {
+    }
+
+    static Optional<String> findMetaContent(String html, String key) {
+        Matcher tagMatcher = META_TAG_PATTERN.matcher(html);
+        while (tagMatcher.find()) {
+            String tag = tagMatcher.group();
+            String property = findAttribute(tag, "property").orElse(null);
+            String name = findAttribute(tag, "name").orElse(null);
+            if (matchesKey(property, key) || matchesKey(name, key)) {
+                return findAttribute(tag, "content").map(HtmlUtils::htmlUnescape);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<String> findAttribute(String tag, String attributeName) {
+        Matcher attrMatcher = ATTR_PATTERN.matcher(tag);
+        while (attrMatcher.find()) {
+            if (attrMatcher.group(1).equalsIgnoreCase(attributeName)) {
+                String value = firstNonNull(attrMatcher.group(3), attrMatcher.group(4), attrMatcher.group(5));
+                return Optional.ofNullable(value);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static boolean matchesKey(String value, String key) {
+        return value != null && value.toLowerCase(Locale.ROOT).equals(key.toLowerCase(Locale.ROOT));
+    }
+
+    private static String firstNonNull(String... values) {
+        for (String value : values) {
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/parser/JsonLdParser.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/parser/JsonLdParser.java
@@ -21,6 +21,7 @@ public class JsonLdParser implements ProductParser {
             "<script[^>]+type\\s*=\\s*['\"]application/ld\\+json['\"][^>]*>(.*?)</script>",
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
+    private static final int MAX_JSON_LD_DEPTH = 20;
 
     private final ObjectMapper objectMapper;
 
@@ -44,19 +45,19 @@ public class JsonLdParser implements ProductParser {
     private ProductParseResult parseJsonLdBlock(String rawJson) {
         try {
             JsonNode root = objectMapper.readTree(HtmlUtils.htmlUnescape(rawJson).trim());
-            return findProduct(root);
+            return findProduct(root, 0);
         } catch (Exception e) {
             return null;
         }
     }
 
-    private ProductParseResult findProduct(JsonNode node) {
-        if (node == null || node.isNull()) {
+    private ProductParseResult findProduct(JsonNode node, int depth) {
+        if (node == null || node.isNull() || depth > MAX_JSON_LD_DEPTH) {
             return null;
         }
         if (node.isArray()) {
             for (JsonNode child : node) {
-                ProductParseResult result = findProduct(child);
+                ProductParseResult result = findProduct(child, depth + 1);
                 if (result != null) {
                     return result;
                 }
@@ -64,7 +65,7 @@ public class JsonLdParser implements ProductParser {
             return null;
         }
         if (node.has("@graph")) {
-            ProductParseResult result = findProduct(node.get("@graph"));
+            ProductParseResult result = findProduct(node.get("@graph"), depth + 1);
             if (result != null) {
                 return result;
             }

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/parser/JsonLdParser.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/parser/JsonLdParser.java
@@ -1,0 +1,160 @@
+package com.weartrack.backend.domain.clothes.link.parser;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weartrack.backend.domain.clothes.entity.SourceShop;
+import com.weartrack.backend.domain.clothes.link.ProductParseResult;
+import com.weartrack.backend.domain.clothes.link.ProductParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.HtmlUtils;
+
+import java.util.Iterator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+@RequiredArgsConstructor
+public class JsonLdParser implements ProductParser {
+
+    private static final Pattern JSON_LD_PATTERN = Pattern.compile(
+            "<script[^>]+type\\s*=\\s*['\"]application/ld\\+json['\"][^>]*>(.*?)</script>",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+    );
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean supports(SourceShop sourceShop) {
+        return true;
+    }
+
+    @Override
+    public ProductParseResult parse(String html, String pageUrl) {
+        Matcher matcher = JSON_LD_PATTERN.matcher(html);
+        while (matcher.find()) {
+            ProductParseResult result = parseJsonLdBlock(matcher.group(1));
+            if (result != null) {
+                return result;
+            }
+        }
+        return new ProductParseResult(null, null, null, null, null, null, null, null);
+    }
+
+    private ProductParseResult parseJsonLdBlock(String rawJson) {
+        try {
+            JsonNode root = objectMapper.readTree(HtmlUtils.htmlUnescape(rawJson).trim());
+            return findProduct(root);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private ProductParseResult findProduct(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isArray()) {
+            for (JsonNode child : node) {
+                ProductParseResult result = findProduct(child);
+                if (result != null) {
+                    return result;
+                }
+            }
+            return null;
+        }
+        if (node.has("@graph")) {
+            ProductParseResult result = findProduct(node.get("@graph"));
+            if (result != null) {
+                return result;
+            }
+        }
+        if (isProductNode(node)) {
+            return fromProductNode(node);
+        }
+        return null;
+    }
+
+    private boolean isProductNode(JsonNode node) {
+        JsonNode type = node.get("@type");
+        if (type == null) {
+            return false;
+        }
+        if (type.isArray()) {
+            Iterator<JsonNode> iterator = type.elements();
+            while (iterator.hasNext()) {
+                if ("Product".equalsIgnoreCase(iterator.next().asText())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return "Product".equalsIgnoreCase(type.asText());
+    }
+
+    private ProductParseResult fromProductNode(JsonNode node) {
+        return new ProductParseResult(
+                text(node, "name"),
+                image(node.get("image")),
+                text(node, "description"),
+                text(node, "url"),
+                price(node.get("offers")),
+                brand(node.get("brand")),
+                text(node, "category"),
+                text(node, "color")
+        );
+    }
+
+    private String image(JsonNode imageNode) {
+        if (imageNode == null || imageNode.isNull()) {
+            return null;
+        }
+        if (imageNode.isArray() && !imageNode.isEmpty()) {
+            return image(imageNode.get(0));
+        }
+        if (imageNode.isObject()) {
+            return text(imageNode, "url");
+        }
+        return imageNode.asText(null);
+    }
+
+    private Integer price(JsonNode offersNode) {
+        if (offersNode == null || offersNode.isNull()) {
+            return null;
+        }
+        if (offersNode.isArray() && !offersNode.isEmpty()) {
+            return price(offersNode.get(0));
+        }
+        String priceText = text(offersNode, "price");
+        if (priceText == null) {
+            priceText = text(offersNode, "lowPrice");
+        }
+        if (priceText == null) {
+            return null;
+        }
+        try {
+            String digitsOnly = priceText.replaceAll("[^0-9]", "");
+            return digitsOnly.isBlank() ? null : Integer.parseInt(digitsOnly);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String brand(JsonNode brandNode) {
+        if (brandNode == null || brandNode.isNull()) {
+            return null;
+        }
+        if (brandNode.isObject()) {
+            return text(brandNode, "name");
+        }
+        return brandNode.asText(null);
+    }
+
+    private String text(JsonNode node, String fieldName) {
+        if (node == null || !node.has(fieldName) || node.get(fieldName).isNull()) {
+            return null;
+        }
+        String value = node.get(fieldName).asText(null);
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/parser/MusinsaParser.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/parser/MusinsaParser.java
@@ -1,0 +1,128 @@
+package com.weartrack.backend.domain.clothes.link.parser;
+
+import com.weartrack.backend.domain.clothes.entity.SourceShop;
+import com.weartrack.backend.domain.clothes.link.ProductParseResult;
+import com.weartrack.backend.domain.clothes.link.ProductParser;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class MusinsaParser implements ProductParser {
+
+    private static final Pattern CATEGORY_PATTERN = Pattern.compile("\uc81c\ud488\ubd84\ub958\\s*:\\s*(.*?)\\s+\ube0c\ub79c\ub4dc\\s*:");
+    private static final Pattern BRAND_PATTERN = Pattern.compile("\ube0c\ub79c\ub4dc\\s*:\\s*(.*?)\\s+\uc81c\ud488\ubc88\ud638\\s*:");
+    private static final Pattern PRODUCT_PATTERN = Pattern.compile("\uc81c\ud488\\s*:\\s*(.*?)(?:\\s+-\\s+[0-9,]+)?$");
+
+    @Override
+    public boolean supports(SourceShop sourceShop) {
+        return sourceShop == SourceShop.MUSINSA;
+    }
+
+    @Override
+    public ProductParseResult parse(String html, String pageUrl) {
+        String description = HtmlMetaExtractor.findMetaContent(html, "og:description")
+                .or(() -> HtmlMetaExtractor.findMetaContent(html, "description"))
+                .orElse(null);
+        String title = HtmlMetaExtractor.findMetaContent(html, "og:title").orElse(null);
+        String productName = firstNonBlank(extract(description, PRODUCT_PATTERN), cleanTitle(title));
+        String sourceCategory = extract(description, CATEGORY_PATTERN);
+
+        return new ProductParseResult(
+                productName,
+                null,
+                description,
+                null,
+                null,
+                extract(description, BRAND_PATTERN),
+                mapCategory(sourceCategory),
+                ColorKeywordMapper.infer(join(productName, title, description))
+        );
+    }
+
+    private String extract(String text, Pattern pattern) {
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+        Matcher matcher = pattern.matcher(text);
+        if (!matcher.find()) {
+            return null;
+        }
+        String value = matcher.group(1).trim();
+        return value.isBlank() ? null : value;
+    }
+
+    private String cleanTitle(String title) {
+        if (title == null || title.isBlank()) {
+            return null;
+        }
+        return title
+                .replaceAll("\\s+-\\s+\uc0ac\uc774\uc988.*$", "")
+                .replaceAll("\\s+\\|\\s*\ubb34\uc2e0\uc0ac$", "")
+                .trim();
+    }
+
+    private String mapCategory(String sourceCategory) {
+        if (sourceCategory == null || sourceCategory.isBlank()) {
+            return null;
+        }
+        if (containsAny(sourceCategory, "\ubc18\uc18c\ub9e4", "\ud2f0\uc154\uce20")) {
+            return "T-shirt";
+        }
+        if (containsAny(sourceCategory, "\uc154\uce20", "\ube14\ub77c\uc6b0\uc2a4")) {
+            return "Shirt";
+        }
+        if (containsAny(sourceCategory, "\uac00\ub514\uac74", "\uce74\ub514\uac74")) {
+            return "Cardigan";
+        }
+        if (containsAny(sourceCategory, "\ub2c8\ud2b8", "\uc2a4\uc6e8\ud130")) {
+            return "Knit";
+        }
+        if (containsAny(sourceCategory, "\ud6c4\ub4dc")) {
+            return "Hoodie";
+        }
+        if (containsAny(sourceCategory, "\uc790\ucf13", "\uc7ac\ud0b7", "\uc810\ud37c")) {
+            return "Jacket";
+        }
+        if (containsAny(sourceCategory, "\ucf54\ud2b8")) {
+            return "Coat";
+        }
+        if (containsAny(sourceCategory, "\ud328\ub529")) {
+            return "Padding";
+        }
+        if (containsAny(sourceCategory, "\ud32c\uce20", "\ubc14\uc9c0", "\ub370\ub2d8", "\uc2ac\ub799\uc2a4")) {
+            return "Pants";
+        }
+        if (containsAny(sourceCategory, "\uc2a4\ucee4\ud2b8", "\uce58\ub9c8")) {
+            return "Skirt";
+        }
+        if (containsAny(sourceCategory, "\uc6d0\ud53c\uc2a4", "\ub4dc\ub808\uc2a4")) {
+            return "Dress";
+        }
+        return null;
+    }
+
+    private boolean containsAny(String text, String... keywords) {
+        for (String keyword : keywords) {
+            if (text.contains(keyword)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String join(String... values) {
+        StringBuilder builder = new StringBuilder();
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                builder.append(value).append(' ');
+            }
+        }
+        return builder.toString();
+    }
+
+    private String firstNonBlank(String value, String fallback) {
+        return value != null && !value.isBlank() ? value : fallback;
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/link/parser/ZigzagParser.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/link/parser/ZigzagParser.java
@@ -1,0 +1,96 @@
+package com.weartrack.backend.domain.clothes.link.parser;
+
+import com.weartrack.backend.domain.clothes.entity.SourceShop;
+import com.weartrack.backend.domain.clothes.link.ProductParseResult;
+import com.weartrack.backend.domain.clothes.link.ProductParser;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ZigzagParser implements ProductParser {
+
+    @Override
+    public boolean supports(SourceShop sourceShop) {
+        return sourceShop == SourceShop.ZIGZAG;
+    }
+
+    @Override
+    public ProductParseResult parse(String html, String pageUrl) {
+        String title = HtmlMetaExtractor.findMetaContent(html, "og:title")
+                .or(() -> HtmlMetaExtractor.findMetaContent(html, "twitter:title"))
+                .orElse(null);
+        String description = HtmlMetaExtractor.findMetaContent(html, "og:description")
+                .or(() -> HtmlMetaExtractor.findMetaContent(html, "description"))
+                .orElse(null);
+
+        return new ProductParseResult(
+                cleanTitle(title),
+                null,
+                description,
+                null,
+                null,
+                null,
+                inferCategory(title),
+                ColorKeywordMapper.infer(firstNonBlank(title, description))
+        );
+    }
+
+    private String cleanTitle(String title) {
+        if (title == null || title.isBlank()) {
+            return null;
+        }
+        return title.trim();
+    }
+
+    private String inferCategory(String title) {
+        if (title == null || title.isBlank()) {
+            return null;
+        }
+        if (containsAny(title, "셔츠", "블라우스")) {
+            return "Shirt";
+        }
+        if (containsAny(title, "티셔츠", "반팔", "긴팔", "슬리브")) {
+            return "T-shirt";
+        }
+        if (containsAny(title, "가디건", "카디건")) {
+            return "Cardigan";
+        }
+        if (containsAny(title, "니트", "스웨터")) {
+            return "Knit";
+        }
+        if (containsAny(title, "후드")) {
+            return "Hoodie";
+        }
+        if (containsAny(title, "자켓", "재킷", "점퍼")) {
+            return "Jacket";
+        }
+        if (containsAny(title, "코트")) {
+            return "Coat";
+        }
+        if (containsAny(title, "패딩")) {
+            return "Padding";
+        }
+        if (containsAny(title, "팬츠", "바지", "슬랙스", "데님")) {
+            return "Pants";
+        }
+        if (containsAny(title, "스커트", "치마")) {
+            return "Skirt";
+        }
+        if (containsAny(title, "원피스", "드레스")) {
+            return "Dress";
+        }
+        return null;
+    }
+
+    private boolean containsAny(String text, String... keywords) {
+        for (String keyword : keywords) {
+            if (text.contains(keyword)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String firstNonBlank(String value, String fallback) {
+        return value != null && !value.isBlank() ? value : fallback;
+    }
+}

--- a/src/main/java/com/weartrack/backend/domain/clothes/repository/ClothesPhotoRepository.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/repository/ClothesPhotoRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface ClothesPhotoRepository extends JpaRepository<ClothesPhoto, Long> {
 
     Optional<ClothesPhoto> findByIdAndMemberId(Long id, Long memberId);
+
+    boolean existsByMemberIdAndSourceUrl(Long memberId, String sourceUrl);
 }

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesPhotoService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesPhotoService.java
@@ -3,6 +3,7 @@ package com.weartrack.backend.domain.clothes.service;
 import com.weartrack.backend.domain.clothes.dto.response.ClothesPhotoCreateResponse;
 import com.weartrack.backend.domain.clothes.entity.AnalysisStatus;
 import com.weartrack.backend.domain.clothes.entity.ClothesPhoto;
+import com.weartrack.backend.domain.clothes.entity.ImageStorageType;
 import com.weartrack.backend.domain.clothes.exception.ClothesErrorCode;
 import com.weartrack.backend.domain.clothes.repository.ClothesPhotoRepository;
 import com.weartrack.backend.global.exception.GeneralException;
@@ -31,6 +32,7 @@ public class ClothesPhotoService {
             ClothesPhoto clothesPhoto = ClothesPhoto.builder()
                     .memberId(memberId)
                     .imageUrl(savedImage.getImageUrl())
+                    .imageStorageType(ImageStorageType.USER_UPLOAD)
                     .analysisStatus(AnalysisStatus.PENDING)
                     .predictedCategory(null)
                     .predictedColor(null)

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/ClothesService.java
@@ -11,6 +11,7 @@ import com.weartrack.backend.domain.clothes.dto.response.ClothesDetailResDto;
 import com.weartrack.backend.domain.clothes.dto.response.ClothesFilterResDto;
 import com.weartrack.backend.domain.clothes.entity.Clothes;
 import com.weartrack.backend.domain.clothes.entity.ClothesPhoto;
+import com.weartrack.backend.domain.clothes.entity.ImageStorageType;
 import com.weartrack.backend.domain.clothes.exception.ClothesErrorCode;
 import com.weartrack.backend.domain.clothes.repository.ClothesPhotoRepository;
 import com.weartrack.backend.domain.clothes.repository.ClothesRepository;
@@ -26,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -40,12 +40,11 @@ public class ClothesService {
 
     @Transactional
     public ClothesCreateResponse createClothes(Long memberId, ClothesCreateRequest request) {
-
         ClothesPhoto clothesPhoto = clothesPhotoRepository.findById(request.photoId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 옷 사진입니다."));
+                .orElseThrow(() -> new GeneralException(ClothesErrorCode.CLOTHES_PHOTO_NOT_FOUND));
 
         if (!clothesPhoto.getMemberId().equals(memberId)) {
-            throw new IllegalArgumentException("본인이 업로드한 옷 사진만 등록할 수 있습니다.");
+            throw new GeneralException(ClothesErrorCode.CLOTHES_PHOTO_NOT_OWNED);
         }
 
         ClosetSection section = closetSectionRepository.findById(request.sectionId())
@@ -63,27 +62,15 @@ public class ClothesService {
         Clothes savedClothes = clothesRepository.save(clothes);
         section.increaseClothesCount();
 
-        return new ClothesCreateResponse(
-                savedClothes.getId(),
-                savedClothes.getClothesPhotoId(),
-                savedClothes.getImageUrl(),
-                savedClothes.getColor(),
-                savedClothes.getCategory(),
-                savedClothes.getPrice(),
-                savedClothes.getClosetSectionId(),
-                savedClothes.getCreatedAt()
-        );
+        return toCreateResponse(savedClothes);
     }
 
-
-    // 색상별, 카테고리별 필터링
     public ClothesFilterResDto filterClothes(
             Long memberId, String color, String category, Pageable pageable) {
 
         Page<Clothes> page = clothesRepository.searchByMemberIdAndFilters(
                 memberId, color, category, pageable);
 
-        // 결과에 등장하는 섹션 ID들만 모아서 한 번에 조회 (N+1 방지)
         List<Long> sectionIds = page.getContent().stream()
                 .map(Clothes::getClosetSectionId)
                 .distinct()
@@ -98,10 +85,7 @@ public class ClothesService {
         return ClothesFilterResDto.from(page, sectionNameMap);
     }
 
-
-    // 옷 상세정보 조회
     public ClothesDetailResDto getClothesDetail(Long memberId, Long clothesId) {
-
         Clothes clothes = clothesRepository.findById(clothesId)
                 .orElseThrow(() -> new GeneralException(ClothesErrorCode.CLOTHES_NOT_FOUND));
 
@@ -115,8 +99,6 @@ public class ClothesService {
         return ClothesDetailResDto.from(clothes, section);
     }
 
-
-    // 옷 정보 수정
     @Transactional
     public ClothesDetailResDto updateClothes(
             Long memberId, Long clothesId, ClothesUpdateRequest request) {
@@ -159,10 +141,8 @@ public class ClothesService {
         return targetSection;
     }
 
-    // 옷 정보 삭제
     @Transactional
     public void deleteClothes(Long memberId, Long clothesId) {
-
         Clothes clothes = clothesRepository.findById(clothesId)
                 .orElseThrow(() -> new GeneralException(ClothesErrorCode.CLOTHES_NOT_FOUND));
 
@@ -173,15 +153,34 @@ public class ClothesService {
             throw new GeneralException(ClothesErrorCode.CLOTHES_NOT_OWNED);
         }
 
-        try {
-            s3StorageService.deleteByUrl(clothes.getImageUrl());
-        } catch (Exception e) {
-            log.warn("S3 이미지 삭제 실패. clothesId={}, imageUrl={}",
-                    clothesId, clothes.getImageUrl(), e);
-        }
+        clothesPhotoRepository.findById(clothes.getClothesPhotoId())
+                .filter(photo -> photo.getImageStorageType() == ImageStorageType.USER_UPLOAD)
+                .ifPresent(photo -> {
+                    try {
+                        s3StorageService.deleteByUrl(photo.getImageUrl());
+                    } catch (Exception e) {
+                        log.warn("S3 image delete failed. clothesId={}, imageUrl={}",
+                                clothesId, photo.getImageUrl(), e);
+                    }
+                });
 
         clothesRepository.delete(clothes);
         section.decreaseClothesCount();
     }
 
+    private ClothesCreateResponse toCreateResponse(Clothes clothes) {
+        return new ClothesCreateResponse(
+                clothes.getId(),
+                clothes.getClothesPhotoId(),
+                clothes.getImageUrl(),
+                clothes.getProductName(),
+                clothes.getColor(),
+                clothes.getCategory(),
+                clothes.getPrice(),
+                clothes.getPurchaseDate(),
+                clothes.getStorageLocation(),
+                clothes.getClosetSectionId(),
+                clothes.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/com/weartrack/backend/domain/clothes/service/ProductLinkService.java
+++ b/src/main/java/com/weartrack/backend/domain/clothes/service/ProductLinkService.java
@@ -1,0 +1,158 @@
+package com.weartrack.backend.domain.clothes.service;
+
+import com.weartrack.backend.domain.closet.entity.ClosetSection;
+import com.weartrack.backend.domain.closet.exception.ClosetErrorCode;
+import com.weartrack.backend.domain.closet.repository.ClosetSectionRepository;
+import com.weartrack.backend.domain.clothes.dto.request.ClothesFromLinkRequest;
+import com.weartrack.backend.domain.clothes.dto.request.ProductLinkPreviewRequest;
+import com.weartrack.backend.domain.clothes.dto.response.ClothesCreateResponse;
+import com.weartrack.backend.domain.clothes.dto.response.ProductLinkPreviewResponse;
+import com.weartrack.backend.domain.clothes.entity.AnalysisStatus;
+import com.weartrack.backend.domain.clothes.entity.Clothes;
+import com.weartrack.backend.domain.clothes.entity.ClothesPhoto;
+import com.weartrack.backend.domain.clothes.entity.ImageStorageType;
+import com.weartrack.backend.domain.clothes.entity.SourceShop;
+import com.weartrack.backend.domain.clothes.exception.ClothesErrorCode;
+import com.weartrack.backend.domain.clothes.link.ProductPage;
+import com.weartrack.backend.domain.clothes.link.ProductPageFetcher;
+import com.weartrack.backend.domain.clothes.link.ProductParseResult;
+import com.weartrack.backend.domain.clothes.link.ProductParser;
+import com.weartrack.backend.domain.clothes.link.ProductUrlNormalizer;
+import com.weartrack.backend.domain.clothes.link.SourceShopResolver;
+import com.weartrack.backend.domain.clothes.link.UrlSafetyValidator;
+import com.weartrack.backend.domain.clothes.link.parser.CommonOgParser;
+import com.weartrack.backend.domain.clothes.link.parser.JsonLdParser;
+import com.weartrack.backend.domain.clothes.repository.ClothesPhotoRepository;
+import com.weartrack.backend.domain.clothes.repository.ClothesRepository;
+import com.weartrack.backend.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URI;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProductLinkService {
+
+    private final ProductUrlNormalizer productUrlNormalizer;
+    private final UrlSafetyValidator urlSafetyValidator;
+    private final SourceShopResolver sourceShopResolver;
+    private final ProductPageFetcher productPageFetcher;
+    private final CommonOgParser commonOgParser;
+    private final JsonLdParser jsonLdParser;
+    private final List<ProductParser> productParsers;
+    private final ClothesPhotoRepository clothesPhotoRepository;
+    private final ClothesRepository clothesRepository;
+    private final ClosetSectionRepository closetSectionRepository;
+
+    public ProductLinkPreviewResponse preview(ProductLinkPreviewRequest request) {
+        String normalizedUrl = productUrlNormalizer.normalize(request.url());
+        SourceShop sourceShop = sourceShopResolver.resolve(normalizedUrl);
+
+        ProductPage page = productPageFetcher.fetch(normalizedUrl);
+        ProductParseResult result = parseProduct(sourceShop, page.html(), page.url());
+
+        if (isBlank(result.productName()) || isBlank(result.imageUrl())) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_PARSE_FAILED);
+        }
+
+        return new ProductLinkPreviewResponse(
+                sourceShop,
+                normalizedUrl,
+                result.productName(),
+                result.imageUrl(),
+                result.price(),
+                result.brandName(),
+                result.category(),
+                result.color(),
+                null
+        );
+    }
+
+    @Transactional
+    public ClothesCreateResponse createFromLink(Long memberId, ClothesFromLinkRequest request) {
+        if (request.imageStorageType() != ImageStorageType.EXTERNAL_URL) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_INVALID_URL);
+        }
+
+        String normalizedSourceUrl = productUrlNormalizer.normalize(request.sourceUrl());
+        urlSafetyValidator.validate(request.imageUrl());
+        SourceShop sourceShop = sourceShopResolver.resolve(normalizedSourceUrl);
+
+        if (clothesPhotoRepository.existsByMemberIdAndSourceUrl(memberId, normalizedSourceUrl)) {
+            throw new GeneralException(ClothesErrorCode.PRODUCT_LINK_DUPLICATED);
+        }
+
+        ClosetSection section = closetSectionRepository.findById(request.sectionId())
+                .orElseThrow(() -> new GeneralException(ClosetErrorCode.SECTION_NOT_FOUND));
+
+        if (!section.getCloset().getMemberId().equals(memberId)) {
+            throw new GeneralException(ClosetErrorCode.SECTION_NOT_OWNED);
+        }
+
+        ClothesPhoto photo = clothesPhotoRepository.save(ClothesPhoto.builder()
+                .memberId(memberId)
+                .imageUrl(request.imageUrl())
+                .imageStorageType(ImageStorageType.EXTERNAL_URL)
+                .sourceShop(sourceShop)
+                .sourceUrl(normalizedSourceUrl)
+                .analysisStatus(AnalysisStatus.SKIPPED)
+                .predictedCategory(request.category())
+                .predictedColor(request.color())
+                .build());
+
+        Clothes clothes = Clothes.builder()
+                .clothesPhotoId(photo.getId())
+                .closetSectionId(section.getSectionId())
+                .imageUrl(request.imageUrl())
+                .productName(request.productName())
+                .color(request.color())
+                .category(request.category())
+                .price(request.price())
+                .purchaseDate(request.purchaseDate())
+                .storageLocation(request.storageLocation())
+                .build();
+
+        Clothes savedClothes = clothesRepository.save(clothes);
+        section.increaseClothesCount();
+
+        return toCreateResponse(savedClothes);
+    }
+
+    private ProductParseResult parseProduct(SourceShop sourceShop, String html, String pageUrl) {
+        ProductParseResult commonResult = commonOgParser.parse(html, pageUrl);
+        ProductParseResult jsonLdResult = jsonLdParser.parse(html, pageUrl);
+        ProductParseResult result = commonResult.merge(jsonLdResult);
+
+        for (ProductParser parser : productParsers) {
+            if (parser == commonOgParser || parser == jsonLdParser || !parser.supports(sourceShop)) {
+                continue;
+            }
+            result = parser.parse(html, pageUrl).merge(result);
+        }
+
+        return result;
+    }
+
+    private ClothesCreateResponse toCreateResponse(Clothes clothes) {
+        return new ClothesCreateResponse(
+                clothes.getId(),
+                clothes.getClothesPhotoId(),
+                clothes.getImageUrl(),
+                clothes.getProductName(),
+                clothes.getColor(),
+                clothes.getCategory(),
+                clothes.getPrice(),
+                clothes.getPurchaseDate(),
+                clothes.getStorageLocation(),
+                clothes.getClosetSectionId(),
+                clothes.getCreatedAt()
+        );
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}


### PR DESCRIPTION
- 상품 URL 기반 미리보기 API 추가
- Open Graph 및 JSON-LD 기반 상품 정보 파싱 구현
- 무신사, 지그재그, 에이블리 파서 확장 구조 추가
- 무신사 상품명, 가격, 브랜드, 카테고리, 색상 후보 추출 지원
- 지그재그 상품명, 가격, 브랜드, 이미지, 카테고리 후보 추출 지원
- 에이블리 파서 기본 구조 추가
- 링크 기반 옷 등록 API 추가
- 링크 등록 시 ClothesPhoto 생성 후 Clothes 생성하도록 기존 등록 흐름 유지
- 외부 쇼핑몰 이미지는 S3에 저장하지 않고 외부 imageUrl만 저장
- 이미지 저장 타입 구분을 위한 imageStorageType 추가
- USER_UPLOAD와 EXTERNAL_URL 이미지 저장 방식 분리
- 링크 기반 등록 시 analysisStatus를 SKIPPED로 저장
- sourceShop, sourceUrl 저장 필드 추가
- memberId와 정규화된 sourceUrl 기준 중복 저장 방지
- utm, fbclid, gclid 등 추적 쿼리 제거 URL 정규화 구현
- localhost, 사설 IP, 내부망 URL 차단을 통한 SSRF 방어 추가
- HTML 요청 timeout, redirect 재검증, 응답 크기 제한 추가
- 기존 직접 업로드 방식은 USER_UPLOAD로 유지
- 삭제 시 USER_UPLOAD만 S3 삭제하고 EXTERNAL_URL은 DB 데이터만 삭제하도록 수정
- 기존 조회 API에서 링크 기반 이미지 URL도 그대로 응답되도록 유지
- 옷 정보에 productName, purchaseDate, storageLocation 필드 추가

### 👀 관련 이슈

• 쇼핑몰 상품 링크 기반 옷 등록 기능 추가
•  외부 쇼핑몰 이미지 저작권 이슈 대응을 위한 외부 URL 저장 방식 적용

### ✨ 작업한 내용

•상품 URL 기반 미리보기 API 추가
•Open Graph 및 JSON-LD 기반 상품 정보 파싱 구현
•무신사, 지그재그, 에이블리 파서 확장 구조 추가
•무신사 상품명, 가격, 브랜드, 카테고리, 색상 후보 추출 지원
•지그재그 상품명, 가격, 브랜드, 이미지, 카테고리 후보 추출 지원
•에이블리 파서 기본 구조 추가
•링크 기반 옷 등록 API 추가
•링크 등록 시 ClothesPhoto 생성 후 Clothes 생성하도록 기존 등록 흐름 유지
•외부 쇼핑몰 이미지는 S3에 저장하지 않고 외부 imageUrl만 저장
•이미지 저장 타입 구분을 위한 imageStorageType 추가
•USER_UPLOAD와 EXTERNAL_URL 이미지 저장 방식 분리
•링크 기반 등록 시 analysisStatus를 SKIPPED로 저장
•sourceShop, sourceUrl 저장 필드 추가
•memberId와 정규화된 sourceUrl 기준 중복 저장 방지
•utm_*, fbclid, gclid 등 추적 쿼리 제거 URL 정규화 구현
•localhost, 사설 IP, 내부망 URL 차단을 통한 SSRF 방어 추가
•HTML 요청 timeout, redirect 재검증, 응답 크기 제한 추가
•기존 직접 업로드 방식은 USER_UPLOAD로 유지
•삭제 시 USER_UPLOAD만 S3 삭제하고 EXTERNAL_URL은 DB 데이터만 삭제하도록 수정
•기존 조회 API에서 링크 기반 이미지 URL도 그대로 응답되도록 유지
•옷 정보에 productName, purchaseDate, storageLocation 필드 추가

### 🌀 PR Point
•링크 기반 등록은 기존 ClothesPhoto → Clothes 흐름을 유지했습니다.
•외부 쇼핑몰 이미지는 저작권 이슈 때문에 절대 S3에 저장하지 않고, 외부 이미지 URL만 저장합니다.
•sourceShop은 프론트 요청값을 신뢰하지 않고, 백엔드에서 sourceUrl 도메인 기준으로 판별합니다.
•from-link 저장 시 memberId + normalizedSourceUrl 기준으로 중복 등록을 막습니다.
•삭제 로직은 imageStorageType 기준으로 분기합니다.
•USER_UPLOAD: S3 이미지 삭제 후 DB 삭제
•EXTERNAL_URL: S3 삭제 없이 DB 데이터만 삭제
•에이블리는 현재 서버 요청 시 403으로 차단되는 케이스가 있어, 파서 구조는 추가했지만 실제 미리보기 성공은 쇼핑몰 접근 허용 여부에 따라 달라질 수 있습니다.
•색상/카테고리는 쇼핑몰 HTML에 정보가 없으면 null로 내려가며, 프론트에서 사용자가 수정/선택하는 흐름이 필요합니다.

### 🍰 참고사항

#### 1. 신규 API 추가 및 흐름
* **[POST] `/api/clothes/link-preview` (상품 미리보기 API)**
  * 상품 URL을 받아 상품 정보를 파싱하여 미리보기 데이터로 반환합니다.
  * DB 저장 및 외부 이미지의 S3 업로드를 수행하지 않는 단순 조회성 API입니다.
* **[POST] `/api/clothes/from-link` (링크 기반 옷 등록 API)**
  * 미리보기 이후 사용자가 최종 확정한 정보를 저장하는 API입니다.
  * 내부적으로 `ClothesPhoto`를 먼저 생성한 후, 생성된 `photoId`를 기반으로 `Clothes`를 생성합니다.
  * 링크 기반 등록 시 이미지 저장 타입은 `imageStorageType = EXTERNAL_URL`로 저장됩니다.

#### 2. DB 변경 사항 및 마이그레이션 필수 (중요 ⚠️)
* 이번 작업으로 `clothes_photo` 테이블에 이미지 출처 관리를 위한 컬럼들이 추가되었습니다.
  * `clothes_photo`: `image_storage_type` (USER_UPLOAD, EXTERNAL_URL), `source_shop`, `source_url`
  * `clothes`: `product_name`, `purchase_date`, `storage_location`
* **[운영 DB 마이그레이션 SQL]**
  기존에 저장되어 있던 직접 업로드 데이터는 `image_storage_type` 값이 `NULL`이므로, 기존 옷 삭제 시 S3 이미지 삭제 로직이 정상 작동하려면 **반드시 아래 쿼리를 실행해야 합니다.**
  ```sql
  UPDATE clothes_photo
  SET image_storage_type = 'USER_UPLOAD'
  WHERE image_storage_type IS NULL;

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 상품 링크를 통한 옷 추가 기능 추가 - 외부 링크에서 상품명, 이미지, 가격 자동 로드
  * 무신사, 에이블리, 지그재그 등 주요 쇼핑몰 지원
  * 옷 정보에 상품명, 구매 날짜, 보관 위치 필드 추가
  * 링크 미리보기 기능으로 저장 전 상품 정보 확인 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->